### PR TITLE
fix: improve douyin/tiktok transcript fallback and unify AI transcript flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,27 +129,13 @@ jobs:
           curl -L -o "src-tauri/bin/${{ matrix.yt_dlp_name }}" "${{ matrix.yt_dlp_url }}"
           chmod +x "src-tauri/bin/${{ matrix.yt_dlp_name }}"
 
-      - name: Build Tauri app (macOS - skip DMG)
-        if: matrix.platform == 'macos-latest'
+      - name: Build Tauri app (unsigned CI build)
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
-          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
           tauriScript: bun run tauri
-          args: --target ${{ matrix.target }} --bundles app
-
-      - name: Build Tauri app (Linux)
-        if: matrix.platform == 'ubuntu-22.04'
-        uses: tauri-apps/tauri-action@v0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
-          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
-        with:
-          tauriScript: bun run tauri
-          args: --target ${{ matrix.target }}
+          args: --target ${{ matrix.target }} --no-bundle
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,13 +129,27 @@ jobs:
           curl -L -o "src-tauri/bin/${{ matrix.yt_dlp_name }}" "${{ matrix.yt_dlp_url }}"
           chmod +x "src-tauri/bin/${{ matrix.yt_dlp_name }}"
 
-      - name: Build Tauri app (unsigned CI build)
+      - name: Build Tauri app (macOS - skip DMG)
+        if: matrix.platform == 'macos-latest'
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
           tauriScript: bun run tauri
-          args: --target ${{ matrix.target }} --no-bundle
+          args: --target ${{ matrix.target }} --bundles app
+
+      - name: Build Tauri app (Linux)
+        if: matrix.platform == 'ubuntu-22.04'
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        with:
+          tauriScript: bun run tauri
+          args: --target ${{ matrix.target }}
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4

--- a/src-tauri/src/commands/video.rs
+++ b/src-tauri/src/commands/video.rs
@@ -16,7 +16,6 @@ fn default_transcript_languages(url: &str) -> Vec<String> {
     let lowered = url.to_lowercase();
     if lowered.contains("douyin.com")
         || lowered.contains("iesdouyin.com")
-        || lowered.contains("tiktok.com")
         || lowered.contains("bilibili.com")
         || lowered.contains("b23.tv")
     {
@@ -26,6 +25,9 @@ fn default_transcript_languages(url: &str) -> Vec<String> {
             "zh".to_string(),
             "en".to_string(),
         ];
+    }
+    if lowered.contains("tiktok.com") {
+        return vec!["en".to_string()];
     }
     vec!["en".to_string()]
 }

--- a/src-tauri/src/commands/video.rs
+++ b/src-tauri/src/commands/video.rs
@@ -12,6 +12,24 @@ use crate::utils::validate_url;
 use crate::utils::CommandExt;
 use crate::database::add_log_internal;
 
+fn default_transcript_languages(url: &str) -> Vec<String> {
+    let lowered = url.to_lowercase();
+    if lowered.contains("douyin.com")
+        || lowered.contains("iesdouyin.com")
+        || lowered.contains("tiktok.com")
+        || lowered.contains("bilibili.com")
+        || lowered.contains("b23.tv")
+    {
+        return vec![
+            "zh-Hans".to_string(),
+            "zh-CN".to_string(),
+            "zh".to_string(),
+            "en".to_string(),
+        ];
+    }
+    vec!["en".to_string()]
+}
+
 /// Get video transcript/subtitles for AI summarization
 #[tauri::command]
 pub async fn get_video_transcript(
@@ -50,9 +68,7 @@ pub async fn get_video_transcript(
     let url_for_info = url.clone();
     
     // Use provided languages or default
-    let lang_list: Vec<String> = languages.unwrap_or_else(|| {
-        vec!["en".to_string()]
-    });
+    let lang_list: Vec<String> = languages.unwrap_or_else(|| default_transcript_languages(&url));
     
     #[cfg(debug_assertions)]
     println!("[TRANSCRIPT] Languages to try: {:?}", lang_list);
@@ -282,6 +298,8 @@ pub async fn get_video_transcript(
                     
                     add_log_internal("info", "Description not relevant (promotional content only)", None, Some(&url)).ok();
                 }
+            } else {
+                add_log_internal("info", "Description fallback returned too little content", None, Some(&url)).ok();
             }
         }
         Ok(Err(e)) => {
@@ -293,6 +311,50 @@ pub async fn get_video_transcript(
             #[cfg(debug_assertions)]
             println!("[TRANSCRIPT] Description fetch timed out");
             add_log_internal("stderr", "Description fetch timed out (45s)", None, Some(&url)).ok();
+        }
+    }
+
+    // Fallback #2: metadata extraction from dump-json (useful for Douyin/TikTok when subtitles are unavailable)
+    if !rate_limited {
+        let metadata_args = vec![
+            "--dump-json",
+            "--no-download",
+            "--no-playlist",
+            "--no-warnings",
+            "--no-cache-dir",
+            "--socket-timeout",
+            "30",
+            "--",
+            &url_for_info,
+        ];
+        let metadata_result = timeout(
+            Duration::from_secs(45),
+            run_ytdlp_json_with_cookies(
+                &app,
+                &metadata_args.iter().copied().collect::<Vec<_>>(),
+                cookie_mode.as_deref(),
+                cookie_browser.as_deref(),
+                cookie_browser_profile.as_deref(),
+                cookie_file_path.as_deref(),
+                proxy_url.as_deref(),
+            ),
+        )
+        .await;
+        match metadata_result {
+            Ok(Ok(json_output)) => {
+                if let Ok(info_json) = serde_json::from_str::<serde_json::Value>(&json_output) {
+                    if let Some(text) = build_metadata_fallback_from_info_json(&info_json) {
+                        add_log_internal("success", "Using metadata fallback content", None, Some(&url)).ok();
+                        return Ok(text);
+                    }
+                }
+            }
+            Ok(Err(e)) => {
+                add_log_internal("stderr", &format!("Metadata fallback failed: {}", e), None, Some(&url)).ok();
+            }
+            Err(_) => {
+                add_log_internal("stderr", "Metadata fallback timed out (45s)", None, Some(&url)).ok();
+            }
         }
     }
     
@@ -390,6 +452,75 @@ fn is_description_content_relevant(title: &str, description: &str) -> bool {
     
     // Default to true if we have enough text content
     text_without_links.split_whitespace().count() > 50
+}
+
+fn build_metadata_fallback_from_info_json(json: &serde_json::Value) -> Option<String> {
+    let title = json
+        .get("title")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .trim();
+    let description = json
+        .get("description")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .trim();
+
+    if !title.is_empty() && !description.is_empty() && description.len() > 50 && is_description_content_relevant(title, description) {
+        return Some(format!("[Video Description - No subtitles available]\nTitle: {}\n\n{}", title, description));
+    }
+
+    let uploader = json
+        .get("uploader")
+        .and_then(|v| v.as_str())
+        .or_else(|| json.get("channel").and_then(|v| v.as_str()))
+        .unwrap_or("")
+        .trim();
+    let upload_date = json.get("upload_date").and_then(|v| v.as_str()).unwrap_or("").trim();
+    let duration = json.get("duration").and_then(|v| v.as_f64()).unwrap_or(0.0);
+    let view_count = json.get("view_count").and_then(|v| v.as_u64()).unwrap_or(0);
+    let like_count = json.get("like_count").and_then(|v| v.as_u64()).unwrap_or(0);
+    let comment_count = json.get("comment_count").and_then(|v| v.as_u64()).unwrap_or(0);
+    let repost_count = json.get("repost_count").and_then(|v| v.as_u64()).unwrap_or(0);
+    let webpage_url = json.get("webpage_url").and_then(|v| v.as_str()).unwrap_or("").trim();
+
+    let mut lines: Vec<String> = Vec::new();
+    if !title.is_empty() {
+        lines.push(format!("Title: {}", title));
+    }
+    if !uploader.is_empty() {
+        lines.push(format!("Uploader: {}", uploader));
+    }
+    if !upload_date.is_empty() {
+        lines.push(format!("Upload date: {}", upload_date));
+    }
+    if duration > 0.0 {
+        lines.push(format!("Duration: {:.0}s", duration));
+    }
+    if view_count > 0 {
+        lines.push(format!("Views: {}", view_count));
+    }
+    if like_count > 0 {
+        lines.push(format!("Likes: {}", like_count));
+    }
+    if comment_count > 0 {
+        lines.push(format!("Comments: {}", comment_count));
+    }
+    if repost_count > 0 {
+        lines.push(format!("Shares/Reposts: {}", repost_count));
+    }
+    if !webpage_url.is_empty() {
+        lines.push(format!("Source URL: {}", webpage_url));
+    }
+
+    if lines.len() < 2 {
+        return None;
+    }
+
+    Some(format!(
+        "[Video Metadata - No subtitles available]\n{}",
+        lines.join("\n")
+    ))
 }
 
 /// Parse VTT or SRT subtitle file to plain text

--- a/src-tauri/src/services/ytdlp.rs
+++ b/src-tauri/src/services/ytdlp.rs
@@ -306,6 +306,27 @@ pub async fn run_ytdlp_with_stderr(app: &AppHandle, args: &[&str]) -> Result<Ytd
 /// Parse yt-dlp stderr for common errors and return user-friendly message
 pub fn parse_ytdlp_error(stderr: &str) -> Option<String> {
     let stderr_lower = stderr.to_lowercase();
+
+    // Browser cookie database locked / unavailable
+    if stderr_lower.contains("could not copy")
+        && stderr_lower.contains("cookie")
+        && stderr_lower.contains("database")
+    {
+        return Some(
+            "Browser cookie database is locked. Please close browser windows and retry, or switch to Cookie File mode in Settings → Network."
+                .to_string(),
+        );
+    }
+
+    // Douyin / TikTok fresh cookies requirement
+    if stderr_lower.contains("fresh cookies")
+        || (stderr_lower.contains("douyin") && stderr_lower.contains("cookies") && stderr_lower.contains("needed"))
+    {
+        return Some(
+            "This Douyin/TikTok content requires fresh login cookies. Please refresh login in browser cookie mode, then retry."
+                .to_string(),
+        );
+    }
     
     // Rate limiting
     if stderr_lower.contains("429") || stderr_lower.contains("too many requests") {

--- a/src/contexts/AIContext.tsx
+++ b/src/contexts/AIContext.tsx
@@ -350,33 +350,14 @@ export function AIProvider({ children }: { children: ReactNode }) {
         return newMap;
       });
 
-      // Get languages from current config
-      const languages = config.transcript_languages || ['en'];
-
-      // Get cookie settings
-      const cookieSettings = loadCookieSettings();
-
-      // Get proxy settings
-      const proxySettings = loadProxySettings();
-
       // Run in background (not awaited, fire-and-forget)
       (async () => {
         try {
           // Fetch transcript
           if (import.meta.env.DEV) {
-            console.log(
-              `[AI] Fetching transcript for URL: ${url}, languages: ${languages.join(', ')}`,
-            );
+            console.log(`[AI] Fetching transcript for URL with fallback chain: ${url}`);
           }
-          const transcript = await invoke<string>('get_video_transcript', {
-            url,
-            languages,
-            cookieMode: cookieSettings.mode,
-            cookieBrowser: cookieSettings.browser || null,
-            cookieBrowserProfile: cookieSettings.browserProfile || null,
-            cookieFilePath: cookieSettings.filePath || null,
-            proxyUrl: buildProxyUrl(proxySettings) || null,
-          });
+          const transcript = await fetchTranscript(url);
 
           if (import.meta.env.DEV) {
             console.log(
@@ -413,7 +394,7 @@ export function AIProvider({ children }: { children: ReactNode }) {
         }
       })();
     },
-    [updateTask, config.transcript_languages, config.enabled],
+    [updateTask, config.enabled, fetchTranscript],
   );
 
   const getSummaryTask = useCallback(
@@ -468,27 +449,11 @@ export function AIProvider({ children }: { children: ReactNode }) {
         return newMap;
       });
 
-      const languages = config.transcript_languages || ['en'];
-
-      // Get cookie settings
-      const cookieSettings = loadCookieSettings();
-
-      // Get proxy settings
-      const proxySettings = loadProxySettings();
-
       // Run in background
       (async () => {
         try {
           // Fetch transcript
-          const transcript = await invoke<string>('get_video_transcript', {
-            url: itemInfo.url,
-            languages,
-            cookieMode: cookieSettings.mode,
-            cookieBrowser: cookieSettings.browser || null,
-            cookieBrowserProfile: cookieSettings.browserProfile || null,
-            cookieFilePath: cookieSettings.filePath || null,
-            proxyUrl: buildProxyUrl(proxySettings) || null,
-          });
+          const transcript = await fetchTranscript(itemInfo.url);
 
           // Update to generating status
           updateTask(taskId, { status: 'generating' });
@@ -525,7 +490,7 @@ export function AIProvider({ children }: { children: ReactNode }) {
         }
       })();
     },
-    [updateTask, config.transcript_languages, config.enabled],
+    [updateTask, config.enabled, fetchTranscript],
   );
 
   return (

--- a/src/contexts/AIContext.tsx
+++ b/src/contexts/AIContext.tsx
@@ -62,6 +62,27 @@ function buildProxyUrl(settings: ProxySettings): string | undefined {
   return `${protocol}://${auth}${settings.host}:${settings.port}`;
 }
 
+function extractErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  if (typeof error === 'string') {
+    return error;
+  }
+
+  try {
+    const serialized = JSON.stringify(error);
+    if (serialized && serialized !== '{}') {
+      return serialized;
+    }
+  } catch {
+    // ignore serialization errors
+  }
+
+  return String(error);
+}
+
 // Task status for background summary generation
 export interface SummaryTask {
   historyId: string;
@@ -230,6 +251,7 @@ export function AIProvider({ children }: { children: ReactNode }) {
       const languages = config.transcript_languages || ['en'];
       const cookieSettings = loadCookieSettings();
       const proxySettings = loadProxySettings();
+      let transcriptError: string | null = null;
 
       // Try YouTube captions first
       try {
@@ -243,14 +265,18 @@ export function AIProvider({ children }: { children: ReactNode }) {
           proxyUrl: buildProxyUrl(proxySettings) || null,
         });
 
-        // Check if we got meaningful transcript
-        if (transcript && transcript.trim().length > 50) {
-          return transcript;
+        const normalizedTranscript = transcript?.trim();
+
+        if (normalizedTranscript) {
+          return normalizedTranscript;
         }
+
+        transcriptError = 'Transcript is empty.';
       } catch (error) {
-        // No YouTube captions available, will try Whisper fallback
+        transcriptError = extractErrorMessage(error);
+
         if (import.meta.env.DEV) {
-          console.log('[AI] YouTube transcript failed, trying Whisper fallback:', error);
+          console.log('[AI] Transcript fetch failed, trying Whisper fallback:', transcriptError);
         }
       }
 
@@ -264,19 +290,34 @@ export function AIProvider({ children }: { children: ReactNode }) {
             console.log('[AI] Using Whisper transcription for:', url);
           }
 
-          return await invoke<string>('transcribe_url_with_whisper', {
-            url,
-            responseFormat: 'text',
-            openaiApiKey: whisperKey,
-            language: languages[0] || null, // Use first preferred language as hint
-            cookieMode: cookieSettings.mode,
-            cookieBrowser: cookieSettings.browser || null,
-            cookieBrowserProfile: cookieSettings.browserProfile || null,
-            cookieFilePath: cookieSettings.filePath || null,
-            proxyUrl: buildProxyUrl(proxySettings) || null,
-            whisperEndpointUrl: config.whisper_endpoint_url || null,
-            whisperModel: config.whisper_model || null,
-          });
+          try {
+            const whisperTranscript = await invoke<string>('transcribe_url_with_whisper', {
+              url,
+              responseFormat: 'text',
+              openaiApiKey: whisperKey,
+              language: languages[0] || null, // Use first preferred language as hint
+              cookieMode: cookieSettings.mode,
+              cookieBrowser: cookieSettings.browser || null,
+              cookieBrowserProfile: cookieSettings.browserProfile || null,
+              cookieFilePath: cookieSettings.filePath || null,
+              proxyUrl: buildProxyUrl(proxySettings) || null,
+              whisperEndpointUrl: config.whisper_endpoint_url || null,
+              whisperModel: config.whisper_model || null,
+            });
+
+            const normalizedWhisperTranscript = whisperTranscript?.trim();
+            if (normalizedWhisperTranscript) {
+              return normalizedWhisperTranscript;
+            }
+
+            throw new Error('Whisper transcription is empty.');
+          } catch (error) {
+            const whisperError = extractErrorMessage(error);
+            const details = transcriptError
+              ? `Transcript fetch failed: ${transcriptError} | Whisper failed: ${whisperError}`
+              : `Whisper failed: ${whisperError}`;
+            throw new Error(details);
+          }
         } else {
           throw new Error(
             'Whisper is enabled but no API key configured. ' +
@@ -285,6 +326,10 @@ export function AIProvider({ children }: { children: ReactNode }) {
                 : 'Please add a Whisper API key in Settings.'),
           );
         }
+      }
+
+      if (transcriptError) {
+        throw new Error(transcriptError);
       }
 
       throw new Error(


### PR DESCRIPTION
## Summary
- improve transcript fallback for Douyin/TikTok/Bilibili by using better default language priorities
- add robust metadata fallback from `yt-dlp --dump-json` when subtitle/description are unavailable
- improve yt-dlp error parsing for cookie DB lock and fresh-cookie-required scenarios
- refactor AI background summary tasks to reuse shared `fetchTranscript()` fallback chain

## Why
Douyin/TikTok often have no directly available subtitles. Previously this caused weak/empty transcript input in some flows and reduced summary quality.

## Validation
- bun run biome check --write .
- bun run tsc -b
- cargo check

All checks pass locally.