### PR TITLE
fix: avoid signing in CI build-test workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,7 @@ jobs:
           curl -L -o "src-tauri/bin/${{ matrix.yt_dlp_name }}" "${{ matrix.yt_dlp_url }}"
           chmod +x "src-tauri/bin/${{ matrix.yt_dlp_name }}"
 
-      - name: Build Tauri app (unsigned CI build)
+      - name: Build Tauri app (compile-only, unsigned)
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -137,13 +137,5 @@ jobs:
           tauriScript: bun run tauri
           args: --target ${{ matrix.target }} --no-bundle
 
-      - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: build-${{ matrix.platform }}
-          path: |
-            src-tauri/target/${{ matrix.target }}/release/bundle/macos/*.app
-            src-tauri/target/${{ matrix.target }}/release/bundle/deb/*.deb
-            src-tauri/target/${{ matrix.target }}/release/bundle/appimage/*.AppImage
-          if-no-files-found: ignore
-          retention-days: 7
+      - name: Skip artifact upload for no-bundle build
+        run: echo "build-test runs compile-only validation with --no-bundle; no bundle artifacts are uploaded."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,27 +129,13 @@ jobs:
           curl -L -o "src-tauri/bin/${{ matrix.yt_dlp_name }}" "${{ matrix.yt_dlp_url }}"
           chmod +x "src-tauri/bin/${{ matrix.yt_dlp_name }}"
 
-      - name: Build Tauri app (macOS - skip DMG)
-        if: matrix.platform == 'macos-latest'
+      - name: Build Tauri app (unsigned CI build)
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
-          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
           tauriScript: bun run tauri
-          args: --target ${{ matrix.target }} --bundles app
-
-      - name: Build Tauri app (Linux)
-        if: matrix.platform == 'ubuntu-22.04'
-        uses: tauri-apps/tauri-action@v0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
-          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
-        with:
-          tauriScript: bun run tauri
-          args: --target ${{ matrix.target }}
+          args: --target ${{ matrix.target }} --no-bundle
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
This PR isolates CI workflow changes from #31, per maintainer request.

Changes:

Update build-test workflow to run unsigned CI build (--no-bundle)
Remove signing key dependency from CI build-test job
Why:

Keep #31 focused on transcript logic only
Review CI behavior independently in a dedicated PR