### PR TITLE
fix(windows): replace native title bar with custom controls

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -5,6 +5,11 @@
   "windows": ["main"],
   "permissions": [
     "core:default",
+    "core:window:allow-start-dragging",
+    "core:window:allow-minimize",
+    "core:window:allow-toggle-maximize",
+    "core:window:allow-close",
+    "core:window:allow-is-maximized",
     "shell:allow-open",
     "dialog:allow-open",
     "dialog:allow-save",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -91,6 +91,13 @@ pub fn run() {
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_notification::init())
         .setup(|app| {
+            // Windows: remove native title bar so the frontend can render
+            // a custom one that transitions seamlessly with the app theme.
+            #[cfg(windows)]
+            if let Some(window) = app.get_webview_window("main") {
+                let _ = window.set_decorations(false);
+            }
+
             // Queue deep links from cold-start arguments so frontend can consume on mount.
             let argv: Vec<String> = std::env::args().collect();
             let initial_links = commands::extract_external_links_from_argv(&argv);

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -1,6 +1,104 @@
+import { getCurrentWindow } from '@tauri-apps/api/window';
 import type { ReactNode } from 'react';
+import { useEffect, useState } from 'react';
 import type { Page } from './Sidebar';
 import { Sidebar } from './Sidebar';
+
+const isMacOS = typeof navigator !== 'undefined' && navigator.platform.includes('Mac');
+const isWindows = typeof navigator !== 'undefined' && navigator.platform.includes('Win');
+
+/** Windows-only window control buttons (minimize / maximize-restore / close). */
+function WindowControls() {
+  const [maximized, setMaximized] = useState(false);
+
+  useEffect(() => {
+    const win = getCurrentWindow();
+    win
+      .isMaximized()
+      .then(setMaximized)
+      .catch(() => {});
+
+    const unlisten = win.onResized(() => {
+      win
+        .isMaximized()
+        .then(setMaximized)
+        .catch(() => {});
+    });
+    return () => {
+      unlisten.then((fn) => fn());
+    };
+  }, []);
+
+  const btnBase =
+    'w-[46px] h-full inline-flex items-center justify-center text-foreground/80 transition-colors';
+
+  return (
+    <div className="flex h-8 shrink-0">
+      <button
+        type="button"
+        onClick={() => getCurrentWindow().minimize()}
+        className={`${btnBase} hover:bg-foreground/10`}
+      >
+        {/* Minimize icon */}
+        <svg width="10" height="1" viewBox="0 0 10 1" className="fill-current" aria-hidden="true">
+          <rect width="10" height="1" />
+        </svg>
+      </button>
+
+      <button
+        type="button"
+        onClick={() => getCurrentWindow().toggleMaximize()}
+        className={`${btnBase} hover:bg-foreground/10`}
+      >
+        {maximized ? (
+          /* Restore icon (two overlapping rectangles) */
+          <svg
+            width="10"
+            height="10"
+            viewBox="0 0 10 10"
+            className="fill-none stroke-current"
+            strokeWidth="1"
+            aria-hidden="true"
+          >
+            <rect x="0" y="2.5" width="7.5" height="7.5" />
+            <polyline points="2.5,2.5 2.5,0 10,0 10,7.5 7.5,7.5" />
+          </svg>
+        ) : (
+          /* Maximize icon */
+          <svg
+            width="10"
+            height="10"
+            viewBox="0 0 10 10"
+            className="fill-none stroke-current"
+            strokeWidth="1"
+            aria-hidden="true"
+          >
+            <rect x="0.5" y="0.5" width="9" height="9" />
+          </svg>
+        )}
+      </button>
+
+      <button
+        type="button"
+        onClick={() => getCurrentWindow().close()}
+        className={`${btnBase} hover:bg-red-500 hover:text-white`}
+      >
+        {/* Close icon */}
+        <svg
+          width="10"
+          height="10"
+          viewBox="0 0 10 10"
+          className="fill-none stroke-current"
+          strokeWidth="1.2"
+          aria-hidden="true"
+        >
+          <line x1="0" y1="0" x2="10" y2="10" />
+          <line x1="10" y1="0" x2="0" y2="10" />
+        </svg>
+      </button>
+    </div>
+  );
+}
 
 interface MainLayoutProps {
   children: ReactNode;
@@ -9,12 +107,32 @@ interface MainLayoutProps {
 }
 
 export function MainLayout({ children, currentPage, onPageChange }: MainLayoutProps) {
-  const isMacOS = typeof navigator !== 'undefined' && navigator.platform.includes('Mac');
-
   return (
     <div className="h-screen flex overflow-hidden bg-background relative">
+      {/* macOS: transparent drag region for overlay title bar */}
       {isMacOS && (
         <div data-tauri-drag-region className="absolute top-0 left-0 right-0 z-30 h-10" />
+      )}
+
+      {/* Windows: custom title bar replacing native decorations */}
+      {isWindows && (
+        <div className="absolute top-0 left-0 right-0 z-30 h-8 flex">
+          {/* Drag area — fills remaining space, separate from buttons */}
+          <div
+            role="toolbar"
+            data-tauri-drag-region
+            className="flex-1 h-full"
+            onMouseDown={(e) => {
+              if (e.button === 0) {
+                e.preventDefault();
+                getCurrentWindow().startDragging();
+              }
+            }}
+            onDoubleClick={() => getCurrentWindow().toggleMaximize()}
+          />
+          {/* Window controls — NOT inside the drag region */}
+          <WindowControls />
+        </div>
       )}
 
       {/* Animated gradient background */}
@@ -32,7 +150,7 @@ export function MainLayout({ children, currentPage, onPageChange }: MainLayoutPr
       {/* Main container - unified floating panel */}
       <div
         className="relative z-10 flex-1 flex min-w-0 p-3 gap-3"
-        style={isMacOS ? { paddingTop: '2.6rem' } : undefined}
+        style={isMacOS || isWindows ? { paddingTop: isMacOS ? '2.6rem' : '2rem' } : undefined}
       >
         {/* Sidebar */}
         <Sidebar currentPage={currentPage} onPageChange={onPageChange} />


### PR DESCRIPTION
## Summary
- Removes native Windows title bar decorations (`set_decorations(false)`) so the app theme fully controls the header area
- Adds custom minimize/maximize-restore/close buttons rendered in the frontend, matching the macOS overlay title bar approach
- Adds required Tauri v2 window permissions (`allow-minimize`, `allow-toggle-maximize`, `allow-close`, `allow-is-maximized`) to `capabilities/default.json`
- Adjusts top padding for Windows to accommodate the custom title bar height

## Problem
On Windows, the native title bar color followed the system theme (e.g. dark blue, light gray) and clashed with the app's own dark/light theme, creating a visual disconnect that didn't exist on macOS.

## Test plan
- [ ] Verify minimize, maximize/restore, and close buttons work on Windows
- [ ] Verify window dragging works by clicking and dragging the title bar area
- [ ] Verify double-clicking the title bar toggles maximize/restore
- [ ] Verify macOS overlay title bar behavior is unchanged
- [ ] Verify theme switching animation covers the entire window seamlessly