### PR TITLE
fix: distinguish cookie DB lock from fresh login cookie errors

### DIFF
--- a/src-tauri/src/services/ytdlp.rs
+++ b/src-tauri/src/services/ytdlp.rs
@@ -442,7 +442,11 @@ pub fn parse_ytdlp_error(stderr: &str) -> Option<BackendError> {
 
     // Douyin / TikTok fresh cookies requirement
     if stderr_lower.contains("fresh cookies")
-        || (stderr_lower.contains("douyin") && stderr_lower.contains("cookies") && stderr_lower.contains("needed"))
+        || stderr_lower.contains("fresh login cookies")
+        || (stderr_lower.contains("douyin")
+            && stderr_lower.contains("cookies")
+            && stderr_lower.contains("fresh")
+            && (stderr_lower.contains("needed") || stderr_lower.contains("requires")))
     {
         return Some(
             BackendError::from_message(

--- a/src-tauri/src/types/error.rs
+++ b/src-tauri/src/types/error.rs
@@ -161,7 +161,13 @@ pub fn infer_error_code(message: &str) -> &'static str {
     if m.contains("could not copy") && m.contains("cookie") && m.contains("database") {
         return code::YT_COOKIE_DB_LOCKED;
     }
-    if m.contains("fresh cookies") {
+    if m.contains("fresh cookies")
+        || m.contains("fresh login cookies")
+        || m.contains("douyin")
+            && m.contains("cookies")
+            && m.contains("fresh")
+            && (m.contains("needed") || m.contains("requires"))
+    {
         return code::YT_FRESH_COOKIES_REQUIRED;
     }
     if m.contains("429") || m.contains("too many requests") || m.contains("rate limited") {
@@ -296,4 +302,22 @@ fn escape_json_string(input: &str) -> String {
         .replace('\n', "\\n")
         .replace('\r', "\\r")
         .replace('\t', "\\t")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{code, infer_error_code};
+
+    #[test]
+    fn detects_fresh_login_cookies_as_fresh_cookie_error() {
+        let message =
+            "This Douyin/TikTok content requires fresh login cookies. Please refresh login and retry.";
+        assert_eq!(infer_error_code(message), code::YT_FRESH_COOKIES_REQUIRED);
+    }
+
+    #[test]
+    fn keeps_generic_cookie_required_errors_out_of_fresh_cookie_code() {
+        let message = "Sign in required. Cookies are required to access this content.";
+        assert_eq!(infer_error_code(message), code::YT_SIGNIN_REQUIRED);
+    }
 }

--- a/src-tauri/tests/ytdlp_parse_error_tests.rs
+++ b/src-tauri/tests/ytdlp_parse_error_tests.rs
@@ -1,0 +1,16 @@
+use app_lib::services::parse_ytdlp_error;
+use app_lib::types::code;
+
+#[test]
+fn parse_ytdlp_error_detects_fresh_login_cookies_phrase() {
+    let stderr = "ERROR: This Douyin/TikTok content requires fresh login cookies. \
+                  Please refresh login in browser cookie mode, then retry.";
+
+    let err = parse_ytdlp_error(stderr).expect("expected fresh cookies backend error");
+    assert_eq!(err.code(), code::YT_FRESH_COOKIES_REQUIRED);
+    assert_eq!(
+        err.message(),
+        "This Douyin/TikTok content requires fresh login cookies. \
+Please refresh login in browser cookie mode, then retry."
+    );
+}

--- a/src/components/BrowserCookieErrorDialog.tsx
+++ b/src/components/BrowserCookieErrorDialog.tsx
@@ -1,8 +1,9 @@
-import { AlertTriangle, Cookie, RefreshCw, X } from 'lucide-react';
+import { AlertTriangle, Cookie, KeyRound, RefreshCw, Settings, X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 
 interface BrowserCookieErrorDialogProps {
   browserName?: string;
+  errorType?: 'db_locked' | 'fresh_required';
   onRetry: () => void;
   onDismiss: () => void;
   onGoToSettings?: () => void;
@@ -10,25 +11,45 @@ interface BrowserCookieErrorDialogProps {
 
 export function BrowserCookieErrorDialog({
   browserName = 'browser',
+  errorType = 'db_locked',
   onRetry,
   onDismiss,
   onGoToSettings,
 }: BrowserCookieErrorDialogProps) {
   const displayBrowserName =
     browserName.charAt(0).toUpperCase() + browserName.slice(1).toLowerCase();
+  const isFreshRequired = errorType === 'fresh_required';
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm">
       <div className="w-full max-w-md mx-4 bg-card border border-border rounded-xl shadow-2xl overflow-hidden">
         {/* Header */}
-        <div className="relative bg-gradient-to-r from-amber-500/20 to-orange-500/10 px-6 py-4">
+        <div
+          className={`relative bg-gradient-to-r px-6 py-4 ${
+            isFreshRequired
+              ? 'from-blue-500/20 to-sky-500/10'
+              : 'from-amber-500/20 to-orange-500/10'
+          }`}
+        >
           <div className="flex items-center gap-3">
-            <div className="p-2 bg-amber-500/20 rounded-lg">
-              <Cookie className="w-5 h-5 text-amber-500" />
+            <div
+              className={`p-2 rounded-lg ${isFreshRequired ? 'bg-blue-500/20' : 'bg-amber-500/20'}`}
+            >
+              {isFreshRequired ? (
+                <KeyRound className="w-5 h-5 text-blue-500" />
+              ) : (
+                <Cookie className="w-5 h-5 text-amber-500" />
+              )}
             </div>
             <div>
-              <h2 className="text-lg font-semibold text-foreground">Cookie Access Failed</h2>
-              <p className="text-sm text-muted-foreground">Browser is blocking cookie access</p>
+              <h2 className="text-lg font-semibold text-foreground">
+                {isFreshRequired ? 'Login Cookies Required' : 'Cookie Access Failed'}
+              </h2>
+              <p className="text-sm text-muted-foreground">
+                {isFreshRequired
+                  ? 'Content requires authentication'
+                  : 'Browser is blocking cookie access'}
+              </p>
             </div>
           </div>
           <button
@@ -42,54 +63,109 @@ export function BrowserCookieErrorDialog({
 
         {/* Content */}
         <div className="px-6 py-4 space-y-4">
-          <div className="flex items-start gap-3 p-3 bg-amber-500/10 rounded-lg border border-amber-500/20">
-            <AlertTriangle className="w-5 h-5 text-amber-500 flex-shrink-0 mt-0.5" />
+          <div
+            className={`flex items-start gap-3 p-3 rounded-lg border ${
+              isFreshRequired
+                ? 'bg-blue-500/10 border-blue-500/20'
+                : 'bg-amber-500/10 border-amber-500/20'
+            }`}
+          >
+            <AlertTriangle
+              className={`w-5 h-5 flex-shrink-0 mt-0.5 ${isFreshRequired ? 'text-blue-500' : 'text-amber-500'}`}
+            />
             <div className="text-sm">
-              <p className="font-medium text-foreground">{displayBrowserName} is currently open</p>
-              <p className="text-muted-foreground mt-1">
-                Chromium-based browsers lock their cookie database while running. Please close{' '}
-                {displayBrowserName} completely and try again.
-              </p>
+              {isFreshRequired ? (
+                <>
+                  <p className="font-medium text-foreground">Authentication needed</p>
+                  <p className="text-muted-foreground mt-1">
+                    This content requires login cookies to download. Enable cookie mode in Settings
+                    → Network to provide authentication.
+                  </p>
+                </>
+              ) : (
+                <>
+                  <p className="font-medium text-foreground">
+                    {displayBrowserName} is currently open
+                  </p>
+                  <p className="text-muted-foreground mt-1">
+                    Chromium-based browsers lock their cookie database while running. Please close{' '}
+                    {displayBrowserName} completely and try again.
+                  </p>
+                </>
+              )}
             </div>
           </div>
 
           <div className="p-3 bg-muted/50 rounded-lg">
             <p className="text-xs font-medium text-foreground mb-2">To fix this issue:</p>
             <ol className="text-xs text-muted-foreground space-y-1 list-decimal list-inside">
-              <li>Close all {displayBrowserName} windows</li>
-              <li>
-                Make sure {displayBrowserName} is not running in the background (check system tray)
-              </li>
-              <li>Click "Retry Download" below</li>
+              {isFreshRequired ? (
+                <>
+                  <li>Go to Settings → Network and enable Cookie mode</li>
+                  <li>Choose "Browser" or "Cookie File" as your authentication source</li>
+                  <li>Click "Retry Download" after updating the settings</li>
+                </>
+              ) : (
+                <>
+                  <li>Close all {displayBrowserName} windows</li>
+                  <li>
+                    Make sure {displayBrowserName} is not running in the background (check system
+                    tray)
+                  </li>
+                  <li>Click "Retry Download" below</li>
+                </>
+              )}
             </ol>
           </div>
 
-          <p className="text-xs text-muted-foreground">
-            <strong>Alternative:</strong> Use "Cookie File" mode in Settings → Network to export
-            cookies using a browser extension.
-          </p>
+          {!isFreshRequired && (
+            <p className="text-xs text-muted-foreground">
+              <strong>Alternative:</strong> Use "Cookie File" mode in Settings → Network to export
+              cookies using a browser extension.
+            </p>
+          )}
         </div>
 
         {/* Actions */}
         <div className="px-6 py-4 bg-muted/30 border-t border-border">
           <div className="flex flex-col gap-2">
-            <Button className="w-full" onClick={onRetry}>
-              <RefreshCw className="w-4 h-4 mr-2" />
-              Retry Download
-            </Button>
+            {isFreshRequired ? (
+              <Button
+                className="w-full"
+                onClick={() => {
+                  onDismiss();
+                  onGoToSettings?.();
+                }}
+              >
+                <Settings className="w-4 h-4 mr-2" />
+                Go to Settings
+              </Button>
+            ) : (
+              <Button className="w-full" onClick={onRetry}>
+                <RefreshCw className="w-4 h-4 mr-2" />
+                Retry Download
+              </Button>
+            )}
             <div className="flex gap-2">
-              {onGoToSettings && (
-                <Button
-                  variant="outline"
-                  size="sm"
-                  className="flex-1"
-                  onClick={() => {
-                    onDismiss();
-                    onGoToSettings();
-                  }}
-                >
-                  Go to Settings
+              {isFreshRequired ? (
+                <Button variant="outline" size="sm" className="flex-1" onClick={onRetry}>
+                  <RefreshCw className="w-4 h-4 mr-2" />
+                  Retry Download
                 </Button>
+              ) : (
+                onGoToSettings && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="flex-1"
+                    onClick={() => {
+                      onDismiss();
+                      onGoToSettings();
+                    }}
+                  >
+                    Go to Settings
+                  </Button>
+                )
               )}
               <Button
                 variant="ghost"

--- a/src/contexts/DownloadContext.tsx
+++ b/src/contexts/DownloadContext.tsx
@@ -17,6 +17,7 @@ import {
   localizeBackendError,
   localizeProgressError,
 } from '@/lib/backend-error';
+import { inferCookieErrorType } from '@/lib/cookie-error';
 import {
   AUTO_RETRY_LIMITS,
   clampAutoRetryDelaySeconds,
@@ -275,7 +276,7 @@ interface DownloadContextType {
   updateSponsorBlockMode: (mode: SponsorBlockMode) => void;
   updateSponsorBlockCategory: (category: SponsorBlockCategory, action: SponsorBlockAction) => void;
   // Cookie error detection
-  cookieError: { show: boolean; itemId?: string } | null;
+  cookieError: { show: boolean; itemId?: string; errorType: 'db_locked' | 'fresh_required' } | null;
   clearCookieError: () => void;
   retryFailedDownload: (itemId: string) => void;
   // Per-item time range
@@ -291,7 +292,11 @@ export function DownloadProvider({ children }: { children: ReactNode }) {
   const [focusedItemId, setFocusedItemId] = useState<string | null>(null);
   const [isDownloading, setIsDownloading] = useState(false);
   const [isExpandingPlaylist, setIsExpandingPlaylist] = useState(false);
-  const [cookieError, setCookieError] = useState<{ show: boolean; itemId?: string } | null>(null);
+  const [cookieError, setCookieError] = useState<{
+    show: boolean;
+    itemId?: string;
+    errorType: 'db_locked' | 'fresh_required';
+  } | null>(null);
 
   // Load saved settings on init
   const [settings, setSettings] = useState<DownloadSettings>(() => {
@@ -453,16 +458,12 @@ export function DownloadProvider({ children }: { children: ReactNode }) {
         });
       }
 
-      // Detect cookie error on Windows (lock error or DPAPI/App-Bound Encryption)
-      const cookieErrorPattern =
-        /could not copy.*cookie|permission denied.*cookies|cookie.*database|failed to.*cookie|failed to decrypt.*dpapi|app.bound.encryption/i;
-      const cookieErrorCodes = new Set(['YT_COOKIE_DB_LOCKED', 'YT_FRESH_COOKIES_REQUIRED']);
-      if (
-        progress.status === 'error' &&
-        ((progress.error_code && cookieErrorCodes.has(progress.error_code)) ||
-          (progress.error_message && cookieErrorPattern.test(progress.error_message)))
-      ) {
-        setCookieError({ show: true, itemId: progress.id });
+      // Detect cookie errors from structured backend codes first, then shared fallback inference.
+      if (progress.status === 'error') {
+        const cookieErrorType = inferCookieErrorType(progress.error_code, progress.error_message);
+        if (cookieErrorType) {
+          setCookieError({ show: true, itemId: progress.id, errorType: cookieErrorType });
+        }
       }
 
       setItems((currentItems) =>

--- a/src/contexts/UniversalContext.tsx
+++ b/src/contexts/UniversalContext.tsx
@@ -17,6 +17,7 @@ import {
   localizeBackendError,
   localizeProgressError,
 } from '@/lib/backend-error';
+import { inferCookieErrorType } from '@/lib/cookie-error';
 import {
   AUTO_RETRY_LIMITS,
   clampAutoRetryDelaySeconds,
@@ -251,7 +252,7 @@ interface UniversalContextType {
   updateLiveFromStart: (enabled: boolean) => void;
   updateAutoRetry: (enabled: boolean, maxAttempts: number, delaySeconds: number) => void;
   // Cookie error detection
-  cookieError: { show: boolean; itemId?: string } | null;
+  cookieError: { show: boolean; itemId?: string; errorType: 'db_locked' | 'fresh_required' } | null;
   clearCookieError: () => void;
   retryFailedDownload: (itemId: string) => void;
   // Per-item time range
@@ -271,7 +272,11 @@ export function UniversalProvider({ children }: { children: ReactNode }) {
   const [items, setItems] = useState<DownloadItem[]>([]);
   const [focusedItemId, setFocusedItemId] = useState<string | null>(null);
   const [isDownloading, setIsDownloading] = useState(false);
-  const [cookieError, setCookieError] = useState<{ show: boolean; itemId?: string } | null>(null);
+  const [cookieError, setCookieError] = useState<{
+    show: boolean;
+    itemId?: string;
+    errorType: 'db_locked' | 'fresh_required';
+  } | null>(null);
 
   // Load saved settings on init
   const [settings, setSettings] = useState<UniversalSettings>(() => {
@@ -374,16 +379,12 @@ export function UniversalProvider({ children }: { children: ReactNode }) {
     const unlisten = listen<DownloadProgress>('download-progress', (event) => {
       const progress = event.payload;
 
-      // Detect cookie error on Windows (lock error or DPAPI/App-Bound Encryption)
-      const cookieErrorPattern =
-        /could not copy.*cookie|permission denied.*cookies|cookie.*database|failed to.*cookie|failed to decrypt.*dpapi|app.bound.encryption/i;
-      const cookieErrorCodes = new Set(['YT_COOKIE_DB_LOCKED', 'YT_FRESH_COOKIES_REQUIRED']);
-      if (
-        progress.status === 'error' &&
-        ((progress.error_code && cookieErrorCodes.has(progress.error_code)) ||
-          (progress.error_message && cookieErrorPattern.test(progress.error_message)))
-      ) {
-        setCookieError({ show: true, itemId: progress.id });
+      // Detect cookie errors from structured backend codes first, then shared fallback inference.
+      if (progress.status === 'error') {
+        const cookieErrorType = inferCookieErrorType(progress.error_code, progress.error_message);
+        if (cookieErrorType) {
+          setCookieError({ show: true, itemId: progress.id, errorType: cookieErrorType });
+        }
       }
 
       setItems((currentItems) =>

--- a/src/lib/backend-error.ts
+++ b/src/lib/backend-error.ts
@@ -55,7 +55,16 @@ export function inferBackendErrorCode(message: string): string {
   if (m.includes('could not copy') && m.includes('cookie') && m.includes('database')) {
     return 'YT_COOKIE_DB_LOCKED';
   }
-  if (m.includes('fresh cookies')) return 'YT_FRESH_COOKIES_REQUIRED';
+  if (
+    m.includes('fresh cookies') ||
+    m.includes('fresh login cookies') ||
+    (m.includes('douyin') &&
+      m.includes('cookies') &&
+      m.includes('fresh') &&
+      (m.includes('needed') || m.includes('requires')))
+  ) {
+    return 'YT_FRESH_COOKIES_REQUIRED';
+  }
   if (m.includes('429') || m.includes('too many requests') || m.includes('rate limited')) {
     return 'YT_RATE_LIMITED';
   }

--- a/src/lib/cookie-error.ts
+++ b/src/lib/cookie-error.ts
@@ -2,14 +2,30 @@ import { inferBackendErrorCode } from '@/lib/backend-error';
 
 export type CookieErrorType = 'db_locked' | 'fresh_required';
 
+function inferCookieErrorTypeFromMessage(errorMessage?: string): CookieErrorType | null {
+  if (!errorMessage) return null;
+
+  const inferredCode = inferBackendErrorCode(errorMessage);
+  if (inferredCode === 'YT_COOKIE_DB_LOCKED') return 'db_locked';
+  if (inferredCode === 'YT_FRESH_COOKIES_REQUIRED') return 'fresh_required';
+
+  const normalizedMessage = errorMessage.toLowerCase();
+  const dbLockedPattern =
+    /permission denied.*cookies?|failed to.*cookie|failed to decrypt.*dpapi|app[\s._-]*bound[\s._-]*encryption/i;
+  const freshCookiesPattern = /fresh(?:\s+login)?\s+cookies|douyin.*cookies.*(?:needed|requires)/i;
+
+  if (dbLockedPattern.test(normalizedMessage)) return 'db_locked';
+  if (freshCookiesPattern.test(normalizedMessage)) return 'fresh_required';
+
+  return null;
+}
+
 export function inferCookieErrorType(
   errorCode?: string,
   errorMessage?: string,
 ): CookieErrorType | null {
-  const resolvedCode =
-    errorCode ?? (errorMessage ? inferBackendErrorCode(errorMessage) : undefined);
+  if (errorCode === 'YT_COOKIE_DB_LOCKED') return 'db_locked';
+  if (errorCode === 'YT_FRESH_COOKIES_REQUIRED') return 'fresh_required';
 
-  if (resolvedCode === 'YT_COOKIE_DB_LOCKED') return 'db_locked';
-  if (resolvedCode === 'YT_FRESH_COOKIES_REQUIRED') return 'fresh_required';
-  return null;
+  return inferCookieErrorTypeFromMessage(errorMessage);
 }

--- a/src/lib/cookie-error.ts
+++ b/src/lib/cookie-error.ts
@@ -1,0 +1,15 @@
+import { inferBackendErrorCode } from '@/lib/backend-error';
+
+export type CookieErrorType = 'db_locked' | 'fresh_required';
+
+export function inferCookieErrorType(
+  errorCode?: string,
+  errorMessage?: string,
+): CookieErrorType | null {
+  const resolvedCode =
+    errorCode ?? (errorMessage ? inferBackendErrorCode(errorMessage) : undefined);
+
+  if (resolvedCode === 'YT_COOKIE_DB_LOCKED') return 'db_locked';
+  if (resolvedCode === 'YT_FRESH_COOKIES_REQUIRED') return 'fresh_required';
+  return null;
+}

--- a/src/pages/DownloadPage.tsx
+++ b/src/pages/DownloadPage.tsx
@@ -288,6 +288,7 @@ export function DownloadPage({ onNavigateToSettings }: DownloadPageProps) {
         return (
           <BrowserCookieErrorDialog
             browserName={cookieSettings.browser}
+            errorType={cookieError.errorType}
             onRetry={() => retryFailedDownload(itemId)}
             onDismiss={clearCookieError}
             onGoToSettings={onNavigateToSettings}

--- a/src/pages/UniversalPage.tsx
+++ b/src/pages/UniversalPage.tsx
@@ -282,6 +282,7 @@ export function UniversalPage({ onNavigateToSettings }: UniversalPageProps) {
         return (
           <BrowserCookieErrorDialog
             browserName={loadCookieSettings().browser}
+            errorType={cookieError.errorType}
             onRetry={() => retryFailedDownload(itemId)}
             onDismiss={clearCookieError}
             onGoToSettings={onNavigateToSettings}

--- a/tests/cookie-error.test.ts
+++ b/tests/cookie-error.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from 'bun:test';
+import { inferCookieErrorType } from '../src/lib/cookie-error';
+
+describe('inferCookieErrorType', () => {
+  test('prefers structured backend error codes', () => {
+    expect(inferCookieErrorType('YT_COOKIE_DB_LOCKED')).toBe('db_locked');
+    expect(inferCookieErrorType('YT_FRESH_COOKIES_REQUIRED')).toBe('fresh_required');
+  });
+
+  test('detects fresh login cookies messages as fresh_required', () => {
+    expect(
+      inferCookieErrorType(
+        undefined,
+        'This Douyin/TikTok content requires fresh login cookies. Please refresh login in browser cookie mode, then retry.',
+      ),
+    ).toBe('fresh_required');
+  });
+
+  test('detects browser cookie database lock errors', () => {
+    expect(
+      inferCookieErrorType(
+        undefined,
+        'ERROR: could not copy Chrome cookie database because the database is locked',
+      ),
+    ).toBe('db_locked');
+  });
+
+  test('does not treat generic cookies required errors as fresh_required', () => {
+    expect(
+      inferCookieErrorType(
+        undefined,
+        'Sign in required. Cookies are required to access this content.',
+      ),
+    ).toBeNull();
+  });
+});

--- a/tests/cookie-error.test.ts
+++ b/tests/cookie-error.test.ts
@@ -25,6 +25,15 @@ describe('inferCookieErrorType', () => {
     ).toBe('db_locked');
   });
 
+  test('falls back to message detection when backend code is generic', () => {
+    expect(
+      inferCookieErrorType(
+        'PROCESS_EXIT_NON_ZERO',
+        'ERROR: failed to decrypt DPAPI protected cookie data because permission denied on cookies',
+      ),
+    ).toBe('db_locked');
+  });
+
   test('does not treat generic cookies required errors as fresh_required', () => {
     expect(
       inferCookieErrorType(


### PR DESCRIPTION
## Summary
- split browser cookie extraction failures into db_locked and resh_required flows in the download and universal pages
- centralize frontend cookie error classification so both contexts share the same logic
- extend frontend and Rust error inference to recognize resh login cookies without misclassifying generic cookies required auth errors
- add regression tests for both the frontend helper and Rust error inference

## Validation
- un run biome check --write .
- un run tsc -b
- un test tests/cookie-error.test.ts
- cargo check
- cargo test types::error::tests::

## Notes
- Full cargo test still has an unrelated existing failure in commands::history::tests::rename_downloaded_file_updates_history_by_id (History entry not found).