### PR TITLE
fix(services): reorder binary path resolution, mux progress, thumbnails

### DIFF
--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,21 +1,24 @@
 fn main() {
-    // Ensure the yt-dlp sidecar placeholder exists so tauri_build::build()
-    // passes its resource path validation during local dev builds.
+    // In debug builds, create a minimal yt-dlp sidecar placeholder so
+    // tauri_build::build() passes externalBin path validation without
+    // requiring the real per-platform binary that CI downloads for
+    // release builds. The placeholder is never executed at runtime;
+    // services/ytdlp.rs rejects files under 1024 bytes and falls
+    // through to app_data_dir/bin or system PATH.
     //
-    // Production builds: CI downloads the real per-platform yt-dlp binary
-    // into src-tauri/bin/ before compilation (see .github/workflows/build.yml).
-    //
-    // Dev builds: the placeholder is never executed at runtime. The fallback
-    // chain in services/ytdlp.rs resolves yt-dlp from app_data_dir/bin/ or
-    // system PATH when the bundled sidecar is absent or not a real binary.
-    let target = std::env::var("TARGET").unwrap_or_default();
-    let ext = if target.contains("windows") { ".exe" } else { "" };
-    let sidecar_path = std::path::PathBuf::from(format!("bin/yt-dlp-{}{}", target, ext));
-    if !sidecar_path.exists() {
-        if let Some(parent) = sidecar_path.parent() {
-            let _ = std::fs::create_dir_all(parent);
+    // Release builds skip this so a missing sidecar binary causes a
+    // build failure, forcing CI to provide the real binary.
+    let profile = std::env::var("PROFILE").unwrap_or_default();
+    if profile != "release" {
+        let target = std::env::var("TARGET").unwrap_or_default();
+        let ext = if target.contains("windows") { ".exe" } else { "" };
+        let sidecar_path = std::path::PathBuf::from(format!("bin/yt-dlp-{}{}", target, ext));
+        if !sidecar_path.exists() {
+            if let Some(parent) = sidecar_path.parent() {
+                let _ = std::fs::create_dir_all(parent);
+            }
+            let _ = std::fs::write(&sidecar_path, b"#!/bin/sh\nexit 1\n");
         }
-        let _ = std::fs::write(&sidecar_path, b"#!/bin/sh\nexit 1\n");
     }
 
     tauri_build::build()

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,3 +1,22 @@
 fn main() {
-  tauri_build::build()
+    // Ensure the yt-dlp sidecar placeholder exists so tauri_build::build()
+    // passes its resource path validation during local dev builds.
+    //
+    // Production builds: CI downloads the real per-platform yt-dlp binary
+    // into src-tauri/bin/ before compilation (see .github/workflows/build.yml).
+    //
+    // Dev builds: the placeholder is never executed at runtime. The fallback
+    // chain in services/ytdlp.rs resolves yt-dlp from app_data_dir/bin/ or
+    // system PATH when the bundled sidecar is absent or not a real binary.
+    let target = std::env::var("TARGET").unwrap_or_default();
+    let ext = if target.contains("windows") { ".exe" } else { "" };
+    let sidecar_path = std::path::PathBuf::from(format!("bin/yt-dlp-{}{}", target, ext));
+    if !sidecar_path.exists() {
+        if let Some(parent) = sidecar_path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        let _ = std::fs::write(&sidecar_path, b"#!/bin/sh\nexit 1\n");
+    }
+
+    tauri_build::build()
 }

--- a/src-tauri/src/commands/dependencies.rs
+++ b/src-tauri/src/commands/dependencies.rs
@@ -910,10 +910,85 @@ pub async fn detect_installed_browsers() -> Result<Vec<DetectedBrowser>, String>
     Ok(browsers)
 }
 
+/// Parse Firefox profiles.ini and return profiles sorted with the active profile first.
+///
+/// Firefox's profiles.ini has three relevant section types:
+///   [Install<hex>]  — contains `Default=<relative-path>` identifying the active profile
+///   [Profile<N>]    — contains `Name=<name>`, `Path=<relative-path>`, `IsRelative=1`
+///
+/// yt-dlp's `--cookies-from-browser firefox:<name>` expects the `Name` field value.
+/// It internally resolves the name to the path via profiles.ini.
+///
+/// The bug this fixes: previously we returned profiles in file order, causing the UI
+/// to auto-select the first profile (often the unused legacy "default" profile) instead
+/// of the active profile where the user's cookies actually live (e.g. "default-release").
+fn parse_firefox_profiles(profiles_ini_path: &str) -> Vec<BrowserProfile> {
+    let content = match std::fs::read_to_string(profiles_ini_path) {
+        Ok(c) => c,
+        Err(_) => return Vec::new(),
+    };
+
+    // Find the active profile path from [Install*] section
+    let mut active_path: Option<String> = None;
+    for line in content.lines() {
+        // [Install*] sections have `Default=<path>` pointing to the active profile
+        if line.starts_with("Default=") && active_path.is_none() {
+            let path = line.trim_start_matches("Default=").trim();
+            if !path.is_empty() && !path.eq_ignore_ascii_case("1") && !path.eq_ignore_ascii_case("0") {
+                // Distinguish `Default=1` (boolean in [Profile*]) from `Default=<path>` (in [Install*])
+                active_path = Some(path.to_string());
+            }
+        }
+    }
+
+    // Parse [Profile*] sections to collect Name and Path pairs
+    struct ProfileEntry {
+        name: String,
+        path: String,
+    }
+    let mut entries: Vec<ProfileEntry> = Vec::new();
+    let mut current_name: Option<String> = None;
+    let mut current_path: Option<String> = None;
+
+    for line in content.lines() {
+        let line = line.trim();
+        if line.starts_with('[') {
+            // Flush previous section
+            if let (Some(name), Some(path)) = (current_name.take(), current_path.take()) {
+                entries.push(ProfileEntry { name, path });
+            }
+        } else if line.starts_with("Name=") {
+            current_name = Some(line.trim_start_matches("Name=").to_string());
+        } else if line.starts_with("Path=") {
+            current_path = Some(line.trim_start_matches("Path=").to_string());
+        }
+    }
+    // Flush final section
+    if let (Some(name), Some(path)) = (current_name, current_path) {
+        entries.push(ProfileEntry { name, path });
+    }
+
+    // Sort: active profile first (matching Install section Default path), then alphabetical
+    entries.sort_by(|a, b| {
+        let a_is_active = active_path.as_ref().map(|ap| a.path == *ap).unwrap_or(false);
+        let b_is_active = active_path.as_ref().map(|ap| b.path == *ap).unwrap_or(false);
+        match (a_is_active, b_is_active) {
+            (true, false) => std::cmp::Ordering::Less,
+            (false, true) => std::cmp::Ordering::Greater,
+            _ => a.name.cmp(&b.name),
+        }
+    });
+
+    entries.into_iter().map(|e| BrowserProfile {
+        folder_name: e.name.clone(),
+        display_name: e.name,
+    }).collect()
+}
+
 #[tauri::command]
 pub async fn get_browser_profiles(browser: String) -> Result<Vec<BrowserProfile>, String> {
     let mut profiles = Vec::new();
-    
+
     // Helper function to read display name from Chrome/Chromium Preferences file
     fn get_chromium_profile_name(prefs_path: &std::path::Path) -> Option<String> {
         if let Ok(content) = std::fs::read_to_string(prefs_path) {
@@ -956,22 +1031,8 @@ pub async fn get_browser_profiles(browser: String) -> Result<Vec<BrowserProfile>
             "vivaldi" => format!("{}/Library/Application Support/Vivaldi", home),
             "opera" => format!("{}/Library/Application Support/com.operasoftware.Opera", home),
             "firefox" => {
-                // Firefox uses profiles.ini - display name is the same as folder name
                 let profiles_ini = format!("{}/Library/Application Support/Firefox/profiles.ini", home);
-                if let Ok(content) = std::fs::read_to_string(&profiles_ini) {
-                    for line in content.lines() {
-                        if line.starts_with("Name=") {
-                            let name = line.trim_start_matches("Name=");
-                            if !name.is_empty() {
-                                profiles.push(BrowserProfile {
-                                    folder_name: name.to_string(),
-                                    display_name: name.to_string(),
-                                });
-                            }
-                        }
-                    }
-                }
-                return Ok(profiles);
+                return Ok(parse_firefox_profiles(&profiles_ini));
             }
             "safari" => return Ok(profiles), // Safari has no profiles
             _ => return Ok(profiles),
@@ -1030,20 +1091,7 @@ pub async fn get_browser_profiles(browser: String) -> Result<Vec<BrowserProfile>
             "opera" => format!("{}\\Opera Software\\Opera Stable", app_data),
             "firefox" => {
                 let profiles_ini = format!("{}\\Mozilla\\Firefox\\profiles.ini", app_data);
-                if let Ok(content) = std::fs::read_to_string(&profiles_ini) {
-                    for line in content.lines() {
-                        if line.starts_with("Name=") {
-                            let name = line.trim_start_matches("Name=");
-                            if !name.is_empty() {
-                                profiles.push(BrowserProfile {
-                                    folder_name: name.to_string(),
-                                    display_name: name.to_string(),
-                                });
-                            }
-                        }
-                    }
-                }
-                return Ok(profiles);
+                return Ok(parse_firefox_profiles(&profiles_ini));
             }
             _ => return Ok(profiles),
         };
@@ -1088,20 +1136,7 @@ pub async fn get_browser_profiles(browser: String) -> Result<Vec<BrowserProfile>
             "opera" => format!("{}/.config/opera", home),
             "firefox" => {
                 let profiles_ini = format!("{}/.mozilla/firefox/profiles.ini", home);
-                if let Ok(content) = std::fs::read_to_string(&profiles_ini) {
-                    for line in content.lines() {
-                        if line.starts_with("Name=") {
-                            let name = line.trim_start_matches("Name=");
-                            if !name.is_empty() {
-                                profiles.push(BrowserProfile {
-                                    folder_name: name.to_string(),
-                                    display_name: name.to_string(),
-                                });
-                            }
-                        }
-                    }
-                }
-                return Ok(profiles);
+                return Ok(parse_firefox_profiles(&profiles_ini));
             }
             _ => return Ok(profiles),
         };

--- a/src-tauri/src/commands/download.rs
+++ b/src-tauri/src/commands/download.rs
@@ -27,7 +27,8 @@ use crate::services::{
 };
 use crate::types::{BackendError, DependencySource, DownloadProgress};
 use crate::utils::{
-    build_format_string, format_size, parse_progress, sanitize_output_path, CommandExt,
+    build_format_string, format_size, parse_ffmpeg_progress, parse_progress,
+    sanitize_output_path, CommandExt,
 };
 
 pub static CANCEL_FLAG: AtomicBool = AtomicBool::new(false);
@@ -1096,6 +1097,29 @@ async fn handle_tokio_download(
                         filepath: None,
                         downloaded_size,
                         elapsed_time,
+                    };
+                    stderr_app.emit("download-progress", progress).ok();
+                } else if let Some((size, speed, time)) = parse_ffmpeg_progress(&line) {
+                    // ffmpeg mux/merge progress (e.g. during --download-sections)
+                    let progress = DownloadProgress {
+                        id: stderr_id.clone(),
+                        percent: 0.0,
+                        speed,
+                        eta: String::new(),
+                        status: "muxing".to_string(),
+                        title: None,
+                        playlist_index: None,
+                        playlist_count: None,
+                        filesize: None,
+                        resolution: None,
+                        format_ext: None,
+                        error_message: None,
+                        error_code: None,
+                        error_params: None,
+                        history_id: None,
+                        filepath: None,
+                        downloaded_size: Some(size),
+                        elapsed_time: Some(time),
                     };
                     stderr_app.emit("download-progress", progress).ok();
                 }

--- a/src-tauri/src/services/deno.rs
+++ b/src-tauri/src/services/deno.rs
@@ -5,59 +5,66 @@ use tokio::process::Command;
 use crate::types::DenoStatus;
 use crate::utils::CommandExt;
 
-/// Get the Deno binary path (app data or system)
+/// Get the Deno binary path.
+///
+/// Resolution order:
+///   1. App-managed binary in app_data_dir/bin/
+///   2. System PATH via which/where (Nix, Homebrew, distro, etc.)
+///   3. ~/.deno/bin/deno fallback (curl installer location)
 pub async fn get_deno_path(app: &AppHandle) -> Option<PathBuf> {
-    // First check app data directory
+    // First check app data directory (app-managed download)
     if let Ok(app_data_dir) = app.path().app_data_dir() {
         let bin_dir = app_data_dir.join("bin");
         #[cfg(windows)]
         let deno_path = bin_dir.join("deno.exe");
         #[cfg(not(windows))]
         let deno_path = bin_dir.join("deno");
-        
+
         if deno_path.exists() {
             return Some(deno_path);
         }
     }
-    
-    // Fallback: check if system deno is available
+
+    // System PATH — honors Nix, Homebrew, distro packages, etc.
     #[cfg(unix)]
     {
-        // Check common deno locations
+        let mut cmd = Command::new("which");
+        cmd.arg("deno");
+        cmd.hide_window();
+        if let Ok(output) = cmd.output().await {
+            if output.status.success() {
+                let path_str = String::from_utf8_lossy(&output.stdout).trim().to_string();
+                if !path_str.is_empty() {
+                    return Some(PathBuf::from(path_str));
+                }
+            }
+        }
+
+        // Fallback: ~/.deno/bin/deno (curl installer location)
         let home = std::env::var("HOME").unwrap_or_default();
         let deno_home = PathBuf::from(&home).join(".deno/bin/deno");
         if deno_home.exists() {
             return Some(deno_home);
         }
-        
-        let mut cmd = Command::new("which");
-        cmd.arg("deno");
-        cmd.hide_window();
-        let output = cmd.output().await.ok()?;
-        
-        if output.status.success() {
-            let path_str = String::from_utf8_lossy(&output.stdout).trim().to_string();
-            if !path_str.is_empty() {
-                return Some(PathBuf::from(path_str));
-            }
-        }
     }
-    
+
     #[cfg(windows)]
     {
         let mut cmd = Command::new("where");
         cmd.arg("deno");
         cmd.hide_window();
-        let output = cmd.output().await.ok()?;
-        
-        if output.status.success() {
-            let path_str = String::from_utf8_lossy(&output.stdout).lines().next()?.to_string();
-            if !path_str.is_empty() {
-                return Some(PathBuf::from(path_str));
+        if let Ok(output) = cmd.output().await {
+            if output.status.success() {
+                if let Some(path_str) = String::from_utf8_lossy(&output.stdout).lines().next() {
+                    let path_str = path_str.to_string();
+                    if !path_str.is_empty() {
+                        return Some(PathBuf::from(path_str));
+                    }
+                }
             }
         }
     }
-    
+
     None
 }
 
@@ -97,33 +104,23 @@ pub async fn check_deno_internal(app: &AppHandle) -> Result<DenoStatus, String> 
         }
     }
     
-    // Check system Deno (including ~/.deno/bin/deno)
-    let home = std::env::var("HOME").unwrap_or_default();
-    let deno_home = PathBuf::from(&home).join(".deno/bin/deno");
-    
-    let (deno_cmd, is_home_deno) = if deno_home.exists() {
-        (deno_home.to_string_lossy().to_string(), true)
-    } else {
-        ("deno".to_string(), false)
-    };
-    
-    let mut cmd = Command::new(&deno_cmd);
+    // Check system Deno: PATH first (Nix, Homebrew, distro), then ~/.deno fallback.
+    // Use "deno" so the OS resolves via PATH. If that fails, try ~/.deno/bin/deno.
+    let mut cmd = Command::new("deno");
     cmd.args(["--version"])
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
     cmd.hide_window();
     let output = cmd.output().await;
-    
-    match output {
-        Ok(output) if output.status.success() => {
+
+    if let Ok(output) = &output {
+        if output.status.success() {
             let stdout = String::from_utf8_lossy(&output.stdout);
             let version = stdout.lines().next()
                 .map(|l| l.trim_start_matches("deno ").split_whitespace().next().unwrap_or("").to_string())
                 .unwrap_or_default();
-            
-            let path = if is_home_deno {
-                Some(deno_home.to_string_lossy().to_string())
-            } else {
+
+            let path = {
                 #[cfg(unix)]
                 {
                     let mut cmd = Command::new("which");
@@ -143,21 +140,47 @@ pub async fn check_deno_internal(app: &AppHandle) -> Result<DenoStatus, String> 
                 #[cfg(not(any(unix, windows)))]
                 { None }
             };
-            
-            Ok(DenoStatus {
+
+            return Ok(DenoStatus {
                 installed: true,
                 version: Some(version),
                 binary_path: path,
                 is_system: true,
-            })
+            });
         }
-        _ => Ok(DenoStatus {
-            installed: false,
-            version: None,
-            binary_path: None,
-            is_system: false,
-        }),
     }
+
+    // Fallback: ~/.deno/bin/deno (curl installer location, not on PATH)
+    let home = std::env::var("HOME").unwrap_or_default();
+    let deno_home = PathBuf::from(&home).join(".deno/bin/deno");
+    if deno_home.exists() {
+        let mut cmd = Command::new(&deno_home);
+        cmd.args(["--version"])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        cmd.hide_window();
+        if let Ok(output) = cmd.output().await {
+            if output.status.success() {
+                let stdout = String::from_utf8_lossy(&output.stdout);
+                let version = stdout.lines().next()
+                    .map(|l| l.trim_start_matches("deno ").split_whitespace().next().unwrap_or("").to_string())
+                    .unwrap_or_default();
+                return Ok(DenoStatus {
+                    installed: true,
+                    version: Some(version),
+                    binary_path: Some(deno_home.to_string_lossy().to_string()),
+                    is_system: true,
+                });
+            }
+        }
+    }
+
+    Ok(DenoStatus {
+        installed: false,
+        version: None,
+        binary_path: None,
+        is_system: false,
+    })
 }
 
 /// Get Deno download URL for current platform

--- a/src-tauri/src/services/ffmpeg.rs
+++ b/src-tauri/src/services/ffmpeg.rs
@@ -70,28 +70,37 @@ fn get_app_ffmpeg_path(app: &AppHandle) -> Option<PathBuf> {
     }
 }
 
+/// Resolve system binary candidates in correct precedence order:
+/// 1. PATH entries (honors the user's environment: Nix, Homebrew, distro, etc.)
+/// 2. Well-known fallback paths (for GUI apps that may not inherit shell PATH)
 fn get_system_binary_candidates(binary_name: &str) -> Vec<PathBuf> {
-    let mut candidates = vec![
-        PathBuf::from("/opt/homebrew/bin").join(binary_name),
-        PathBuf::from("/usr/local/bin").join(binary_name),
-        PathBuf::from("/usr/bin").join(binary_name),
-    ];
-
-    if let Ok(path_var) = std::env::var("PATH") {
-        for dir in std::env::split_paths(&path_var) {
-            candidates.push(dir.join(binary_name));
-        }
-    }
-
-    let mut unique = Vec::new();
+    let mut candidates = Vec::new();
     let mut seen = HashSet::new();
-    for path in candidates {
+
+    let mut push_unique = |path: PathBuf| {
         let key = path.to_string_lossy().to_string();
         if seen.insert(key) {
-            unique.push(path);
+            candidates.push(path);
+        }
+    };
+
+    // PATH first — this is the OS-level contract for binary resolution.
+    // Nix, Homebrew, distro packages, and user installs all express
+    // their binaries through PATH.
+    if let Ok(path_var) = std::env::var("PATH") {
+        for dir in std::env::split_paths(&path_var) {
+            push_unique(dir.join(binary_name));
         }
     }
-    unique
+
+    // Well-known fallback locations for environments where PATH may not
+    // include these (e.g., macOS GUI apps launched from Finder/Dock that
+    // don't inherit the user's shell PATH).
+    push_unique(PathBuf::from("/opt/homebrew/bin").join(binary_name));
+    push_unique(PathBuf::from("/usr/local/bin").join(binary_name));
+    push_unique(PathBuf::from("/usr/bin").join(binary_name));
+
+    candidates
 }
 
 fn get_system_ffmpeg_path() -> Option<PathBuf> {

--- a/src-tauri/src/services/ytdlp.rs
+++ b/src-tauri/src/services/ytdlp.rs
@@ -80,28 +80,37 @@ pub async fn set_ytdlp_source(app: &AppHandle, source: &DependencySource) -> Res
     Ok(())
 }
 
+/// Resolve system binary candidates in correct precedence order:
+/// 1. PATH entries (honors the user's environment: Nix, Homebrew, distro, etc.)
+/// 2. Well-known fallback paths (for GUI apps that may not inherit shell PATH)
 fn get_system_binary_candidates(binary_name: &str) -> Vec<PathBuf> {
-    let mut candidates = vec![
-        PathBuf::from("/opt/homebrew/bin").join(binary_name),
-        PathBuf::from("/usr/local/bin").join(binary_name),
-        PathBuf::from("/usr/bin").join(binary_name),
-    ];
-
-    if let Ok(path_var) = std::env::var("PATH") {
-        for dir in std::env::split_paths(&path_var) {
-            candidates.push(dir.join(binary_name));
-        }
-    }
-
-    let mut unique = Vec::new();
+    let mut candidates = Vec::new();
     let mut seen = HashSet::new();
-    for path in candidates {
+
+    let mut push_unique = |path: PathBuf| {
         let key = path.to_string_lossy().to_string();
         if seen.insert(key) {
-            unique.push(path);
+            candidates.push(path);
+        }
+    };
+
+    // PATH first — this is the OS-level contract for binary resolution.
+    // Nix, Homebrew, distro packages, and user installs all express
+    // their binaries through PATH.
+    if let Ok(path_var) = std::env::var("PATH") {
+        for dir in std::env::split_paths(&path_var) {
+            push_unique(dir.join(binary_name));
         }
     }
-    unique
+
+    // Well-known fallback locations for environments where PATH may not
+    // include these (e.g., macOS GUI apps launched from Finder/Dock that
+    // don't inherit the user's shell PATH).
+    push_unique(PathBuf::from("/opt/homebrew/bin").join(binary_name));
+    push_unique(PathBuf::from("/usr/local/bin").join(binary_name));
+    push_unique(PathBuf::from("/usr/bin").join(binary_name));
+
+    candidates
 }
 
 fn get_system_ytdlp_path() -> Option<PathBuf> {
@@ -185,18 +194,26 @@ fn get_legacy_ytdlp_path(app: &AppHandle) -> Option<PathBuf> {
     })
 }
 
-/// Get the bundled yt-dlp path
+/// Get the bundled yt-dlp path.
+/// Returns None if the file doesn't exist or is an empty placeholder
+/// (build.rs creates empty placeholders for dev builds; CI provides the real binary).
 fn get_bundled_ytdlp_path() -> Option<PathBuf> {
     #[cfg(windows)]
     let binary_name = "yt-dlp.exe";
     #[cfg(not(windows))]
     let binary_name = "yt-dlp";
-    
-    // Check next to executable first
+
     if let Ok(exe_path) = std::env::current_exe() {
         if let Some(exe_dir) = exe_path.parent() {
             let bundled = exe_dir.join(binary_name);
             if bundled.exists() {
+                // Reject empty placeholder files created by build.rs for dev builds.
+                // A real yt-dlp binary is several MB; an empty file is not usable.
+                if let Ok(meta) = std::fs::metadata(&bundled) {
+                    if meta.len() < 1024 {
+                        return None;
+                    }
+                }
                 return Some(bundled);
             }
         }
@@ -290,7 +307,13 @@ pub fn get_channel_api_url(channel: &YtdlpChannel) -> Option<&'static str> {
     }
 }
 
-/// Get the path to yt-dlp binary based on current channel setting
+/// Get the path to yt-dlp binary based on current channel setting.
+///
+/// Resolution order for source=Auto (default):
+///   1. User-updated binary in app_data_dir/bin/ (legacy or channel-specific)
+///   2. Bundled sidecar (real binary, not empty placeholder from dev builds)
+///   3. System PATH (Nix, Homebrew, distro package manager, etc.)
+///
 /// Returns: (path, is_bundled)
 pub async fn get_ytdlp_path(app: &AppHandle) -> Option<(PathBuf, bool)> {
     let source = get_ytdlp_source(app).await;
@@ -300,14 +323,14 @@ pub async fn get_ytdlp_path(app: &AppHandle) -> Option<(PathBuf, bool)> {
     }
 
     let channel = get_ytdlp_channel(app).await;
-    
+
     match channel {
         YtdlpChannel::Bundled => {
             // Prefer user-updated legacy binary so bundled update actually takes effect.
             if let Some(legacy_binary) = get_legacy_ytdlp_path(app) {
                 return Some((legacy_binary, false));
             }
-            // Use bundled version
+            // Use bundled version (rejects empty placeholders from dev builds)
             if let Some(bundled) = get_bundled_ytdlp_path() {
                 return Some((bundled, true));
             }
@@ -325,12 +348,21 @@ pub async fn get_ytdlp_path(app: &AppHandle) -> Option<(PathBuf, bool)> {
             }
         }
     }
-    
+
     // Final fallback: check app_data_dir/bin/yt-dlp (legacy location)
     if let Some(legacy_binary) = get_legacy_ytdlp_path(app) {
         return Some((legacy_binary, false));
     }
-    
+
+    // Last resort for Auto mode: check system PATH.
+    // This covers Nix devshells, system package managers, and any other
+    // environment where yt-dlp is available on PATH but not bundled.
+    if source == DependencySource::Auto {
+        if let Some(system_path) = get_system_ytdlp_path() {
+            return Some((system_path, false));
+        }
+    }
+
     None
 }
 

--- a/src-tauri/src/utils/progress.rs
+++ b/src-tauri/src/utils/progress.rs
@@ -92,3 +92,51 @@ pub fn parse_progress(
 
     None
 }
+
+/// Parse ffmpeg stderr progress output emitted during mux/merge/postprocess.
+///
+/// ffmpeg writes lines like:
+///   frame=   75 fps=0.0 q=-1.0 Lsize=     133KiB time=00:00:05.00 bitrate= 217.7kbits/s speed= 223x
+///
+/// Returns (downloaded_size, speed, elapsed_time) when matched.
+/// - downloaded_size: output file size so far (e.g. "133KiB")
+/// - speed:          processing speed (e.g. "223x")
+/// - elapsed_time:   mux progress timestamp (e.g. "00:00:05.00")
+pub fn parse_ffmpeg_progress(line: &str) -> Option<(String, String, String)> {
+    // Quick guard: ffmpeg progress lines always contain both "time=" and "speed="
+    if !line.contains("time=") || !line.contains("speed=") {
+        return None;
+    }
+
+    let mut size = String::new();
+    let mut speed = String::new();
+    let mut time = String::new();
+
+    // Extract Lsize= or size= value
+    if let Some(re) = regex::Regex::new(r"[Ll]?size=\s*([\d.]+\s*\w+)").ok() {
+        if let Some(caps) = re.captures(line) {
+            size = caps.get(1).map(|m| m.as_str().trim().to_string()).unwrap_or_default();
+        }
+    }
+
+    // Extract speed= value (e.g. "223x" or "1.5x")
+    if let Some(re) = regex::Regex::new(r"speed=\s*([\d.]+x)").ok() {
+        if let Some(caps) = re.captures(line) {
+            speed = caps.get(1).map(|m| m.as_str().to_string()).unwrap_or_default();
+        }
+    }
+
+    // Extract time= value (e.g. "00:00:05.00")
+    if let Some(re) = regex::Regex::new(r"time=\s*(\d{2}:\d{2}:\d{2}(?:\.\d+)?)").ok() {
+        if let Some(caps) = re.captures(line) {
+            time = caps.get(1).map(|m| m.as_str().to_string()).unwrap_or_default();
+        }
+    }
+
+    // Must have at least time to be a valid ffmpeg progress line
+    if time.is_empty() {
+        return None;
+    }
+
+    Some((size, speed, time))
+}

--- a/src/components/download/QueueItem.tsx
+++ b/src/components/download/QueueItem.tsx
@@ -299,8 +299,8 @@ export function QueueItem({
             {/* Progress Bar at bottom */}
             <div className="absolute bottom-0 left-0 right-0 p-2">
               <div className="h-1.5 rounded-full overflow-hidden bg-white/20 mb-1 backdrop-blur-sm">
-                {/* Live stream: indeterminate shimmer progress bar */}
-                {item.isLive && item.progress === 0 ? (
+                {/* Indeterminate shimmer: live streams or ffmpeg muxing */}
+                {(item.isLive || item.isMuxing) && item.progress === 0 ? (
                   <div
                     className="h-full w-full rounded-full animate-shimmer"
                     style={{
@@ -331,7 +331,7 @@ export function QueueItem({
                 )}
               </div>
               <div className="flex items-center justify-between text-[10px] text-white/90 font-medium">
-                {/* Live stream: show "LIVE • elapsed time" only */}
+                {/* Live stream: show "LIVE • elapsed time" */}
                 {item.isLive && item.progress === 0 ? (
                   <div className="flex items-center gap-1.5">
                     <span className="flex items-center gap-1 text-red-400">
@@ -342,6 +342,22 @@ export function QueueItem({
                       <>
                         <span className="text-white/50">•</span>
                         <span>{item.elapsedTime}</span>
+                      </>
+                    )}
+                  </div>
+                ) : item.isMuxing && item.progress === 0 ? (
+                  <div className="flex items-center gap-1.5">
+                    <span className="text-blue-300">Muxing</span>
+                    {item.elapsedTime && (
+                      <>
+                        <span className="text-white/50">•</span>
+                        <span>{item.elapsedTime}</span>
+                      </>
+                    )}
+                    {item.speed && (
+                      <>
+                        <span className="text-white/50">•</span>
+                        <span>{item.speed}</span>
                       </>
                     )}
                   </div>

--- a/src/components/download/QueueItem.tsx
+++ b/src/components/download/QueueItem.tsx
@@ -347,7 +347,7 @@ export function QueueItem({
                   </div>
                 ) : item.isMuxing && item.progress === 0 ? (
                   <div className="flex items-center gap-1.5">
-                    <span className="text-blue-300">Muxing</span>
+                    <span className="text-blue-300">{t('queue.status.muxing')}</span>
                     {item.elapsedTime && (
                       <>
                         <span className="text-white/50">•</span>

--- a/src/components/download/UniversalQueueItem.tsx
+++ b/src/components/download/UniversalQueueItem.tsx
@@ -123,9 +123,10 @@ export function UniversalQueueItem({
   const [thumbError, setThumbError] = useState(false);
 
   // Reset thumb error when the thumbnail source changes (e.g. metadata fetch completes)
+  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional re-run when thumbnail changes
   useEffect(() => {
     setThumbError(false);
-  }, [item.thumbnail, item.url]);
+  }, [item.thumbnail]);
 
   const videoId = getYouTubeVideoId(item.url);
   const thumbnailUrl =
@@ -363,7 +364,7 @@ export function UniversalQueueItem({
                   </div>
                 ) : item.isMuxing && item.progress === 0 ? (
                   <div className="flex items-center gap-1.5">
-                    <span className="text-blue-300">Muxing</span>
+                    <span className="text-blue-300">{t('queue.status.muxing')}</span>
                     {item.elapsedTime && (
                       <>
                         <span className="text-white/50">•</span>

--- a/src/components/download/UniversalQueueItem.tsx
+++ b/src/components/download/UniversalQueueItem.tsx
@@ -18,7 +18,7 @@ import {
   X,
   XCircle,
 } from 'lucide-react';
-import { type ChangeEvent, useCallback, useMemo, useState } from 'react';
+import { type ChangeEvent, useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { SimpleMarkdown } from '@/components/ui/simple-markdown';
 import { useAI } from '@/contexts/AIContext';
@@ -78,6 +78,12 @@ function formatFileSize(bytes: number): string {
   return `${bytes} B`;
 }
 
+// Extract YouTube video ID from URL for thumbnail fallback
+function getYouTubeVideoId(url: string): string | null {
+  const match = url.match(/(?:youtube\.com\/watch\?v=|youtu\.be\/)([^&?]+)/);
+  return match ? match[1] : null;
+}
+
 // Helper to format quality display
 function formatQuality(quality: string): string {
   const qualityMap: Record<string, string> = {
@@ -115,6 +121,19 @@ export function UniversalQueueItem({
   const ai = useAI();
   const [showFullSummary, setShowFullSummary] = useState(false);
   const [thumbError, setThumbError] = useState(false);
+
+  // Reset thumb error when the thumbnail source changes (e.g. metadata fetch completes)
+  useEffect(() => {
+    setThumbError(false);
+  }, [item.thumbnail, item.url]);
+
+  const videoId = getYouTubeVideoId(item.url);
+  const thumbnailUrl =
+    item.thumbnail && !thumbError
+      ? item.thumbnail
+      : videoId
+        ? `https://img.youtube.com/vi/${videoId}/mqdefault.jpg`
+        : null;
   const [showTimeRange, setShowTimeRange] = useState(false);
   const [timeStart, setTimeStart] = useState('');
   const [timeEnd, setTimeEnd] = useState('');
@@ -268,9 +287,9 @@ export function UniversalQueueItem({
     >
       {/* Thumbnail Placeholder */}
       <div className="relative flex-shrink-0 w-28 h-[72px] sm:w-36 sm:h-20 rounded-lg overflow-hidden bg-muted">
-        {item.thumbnail && !thumbError ? (
+        {thumbnailUrl ? (
           <img
-            src={item.thumbnail}
+            src={thumbnailUrl}
             alt=""
             className={cn(
               'w-full h-full object-cover transition-all duration-300',
@@ -296,8 +315,8 @@ export function UniversalQueueItem({
             {/* Progress Bar at bottom */}
             <div className="absolute bottom-0 left-0 right-0 p-2">
               <div className="h-1.5 rounded-full overflow-hidden bg-white/20 mb-1 backdrop-blur-sm">
-                {/* Live stream: indeterminate shimmer progress bar */}
-                {item.isLive && item.progress === 0 ? (
+                {/* Indeterminate shimmer: live streams or ffmpeg muxing */}
+                {(item.isLive || item.isMuxing) && item.progress === 0 ? (
                   <div
                     className="h-full w-full rounded-full animate-shimmer"
                     style={{
@@ -328,7 +347,7 @@ export function UniversalQueueItem({
                 )}
               </div>
               <div className="flex items-center justify-between text-[10px] text-white/90 font-medium">
-                {/* Live stream: show "LIVE • elapsed time" only */}
+                {/* Live stream: show "LIVE • elapsed time" */}
                 {item.isLive && item.progress === 0 ? (
                   <div className="flex items-center gap-1.5">
                     <span className="flex items-center gap-1 text-red-400">
@@ -339,6 +358,22 @@ export function UniversalQueueItem({
                       <>
                         <span className="text-white/50">•</span>
                         <span>{item.elapsedTime}</span>
+                      </>
+                    )}
+                  </div>
+                ) : item.isMuxing && item.progress === 0 ? (
+                  <div className="flex items-center gap-1.5">
+                    <span className="text-blue-300">Muxing</span>
+                    {item.elapsedTime && (
+                      <>
+                        <span className="text-white/50">•</span>
+                        <span>{item.elapsedTime}</span>
+                      </>
+                    )}
+                    {item.speed && (
+                      <>
+                        <span className="text-white/50">•</span>
+                        <span>{item.speed}</span>
                       </>
                     )}
                   </div>

--- a/src/contexts/DownloadContext.tsx
+++ b/src/contexts/DownloadContext.tsx
@@ -490,8 +490,15 @@ export function DownloadProvider({ children }: { children: ReactNode }) {
                 playlistTotal: progress.playlist_count,
                 downloadedSize: progress.downloaded_size,
                 elapsedTime: progress.elapsed_time,
-                // Auto-detect live stream if we receive downloaded_size (live stream format)
-                isLive: progress.downloaded_size ? true : item.isLive,
+                // Auto-detect live stream (downloaded_size without muxing status)
+                isLive:
+                  progress.status === 'muxing'
+                    ? item.isLive
+                    : progress.downloaded_size
+                      ? true
+                      : item.isLive,
+                // Detect ffmpeg mux/merge phase (e.g. --download-sections)
+                isMuxing: progress.status === 'muxing',
                 // Store completed info when finished
                 ...(progress.status === 'finished'
                   ? {

--- a/src/contexts/UniversalContext.tsx
+++ b/src/contexts/UniversalContext.tsx
@@ -409,8 +409,15 @@ export function UniversalProvider({ children }: { children: ReactNode }) {
                 retryState: undefined,
                 downloadedSize: progress.downloaded_size,
                 elapsedTime: progress.elapsed_time,
-                // Auto-detect live stream if we receive downloaded_size (live stream format)
-                isLive: progress.downloaded_size ? true : item.isLive,
+                // Auto-detect live stream (downloaded_size without muxing status)
+                isLive:
+                  progress.status === 'muxing'
+                    ? item.isLive
+                    : progress.downloaded_size
+                      ? true
+                      : item.isLive,
+                // Detect ffmpeg mux/merge phase (e.g. --download-sections)
+                isMuxing: progress.status === 'muxing',
                 // Store completed info when finished
                 ...(progress.status === 'finished'
                   ? {

--- a/src/i18n/locales/en/download.json
+++ b/src/i18n/locales/en/download.json
@@ -130,7 +130,8 @@
       "completed": "Completed",
       "failed": "Failed",
       "failedHint": "View Logs page for details",
-      "retrying": "Retry {{current}}/{{total}} in {{seconds}}s"
+      "retrying": "Retry {{current}}/{{total}} in {{seconds}}s",
+      "muxing": "Muxing"
     },
     "summarize": "Summarize",
     "openFolder": "Show in folder",

--- a/src/i18n/locales/en/universal.json
+++ b/src/i18n/locales/en/universal.json
@@ -96,7 +96,8 @@
       "completed": "Completed",
       "failed": "Failed",
       "failedHint": "View Logs page for details",
-      "retrying": "Retry {{current}}/{{total}} in {{seconds}}s"
+      "retrying": "Retry {{current}}/{{total}} in {{seconds}}s",
+      "muxing": "Muxing"
     },
     "summarize": "Summarize",
     "openFolder": "Show in folder",

--- a/src/i18n/locales/fr/download.json
+++ b/src/i18n/locales/fr/download.json
@@ -130,7 +130,8 @@
       "completed": "Terminé",
       "failed": "Échec",
       "failedHint": "Voir la page Journaux pour les détails",
-      "retrying": "Nouvelle tentative {{current}}/{{total}} dans {{seconds}}s"
+      "retrying": "Nouvelle tentative {{current}}/{{total}} dans {{seconds}}s",
+      "muxing": "Fusion"
     },
     "summarize": "Résumer",
     "fetchingTranscript": "Récupération de la transcription...",

--- a/src/i18n/locales/fr/universal.json
+++ b/src/i18n/locales/fr/universal.json
@@ -96,7 +96,8 @@
       "completed": "Terminé",
       "failed": "Échec",
       "failedHint": "Voir la page Journaux pour les détails",
-      "retrying": "Nouvelle tentative {{current}}/{{total}} dans {{seconds}}s"
+      "retrying": "Nouvelle tentative {{current}}/{{total}} dans {{seconds}}s",
+      "muxing": "Fusion"
     },
     "summarize": "Résumer",
     "fetchingTranscript": "Récupération de la transcription...",

--- a/src/i18n/locales/pt/download.json
+++ b/src/i18n/locales/pt/download.json
@@ -130,7 +130,8 @@
       "completed": "Concluído",
       "failed": "Falhou",
       "failedHint": "Visualize os Registros para detalhes",
-      "retrying": "Tentando {{current}}/{{total}} em {{seconds}}s"
+      "retrying": "Tentando {{current}}/{{total}} em {{seconds}}s",
+      "muxing": "Mesclando"
     },
     "summarize": "Resumir",
     "fetchingTranscript": "Buscando transcrição...",

--- a/src/i18n/locales/pt/universal.json
+++ b/src/i18n/locales/pt/universal.json
@@ -96,7 +96,8 @@
       "completed": "Concluído",
       "failed": "Falhou",
       "failedHint": "Visualize a página de Registros para detalhes",
-      "retrying": "Tentando {{current}}/{{total}} em {{seconds}}s"
+      "retrying": "Tentando {{current}}/{{total}} em {{seconds}}s",
+      "muxing": "Mesclando"
     },
     "summarize": "Resumir",
     "fetchingTranscript": "Buscando transcrição...",

--- a/src/i18n/locales/ru/download.json
+++ b/src/i18n/locales/ru/download.json
@@ -130,7 +130,8 @@
       "completed": "Завершено",
       "failed": "Ошибка",
       "failedHint": "Смотрите страницу Журналов для подробностей",
-      "retrying": "Попытка {{current}}/{{total}} через {{seconds}}с"
+      "retrying": "Попытка {{current}}/{{total}} через {{seconds}}с",
+      "muxing": "Сведение"
     },
     "summarize": "Сводка",
     "fetchingTranscript": "Получение транскрипции...",

--- a/src/i18n/locales/ru/universal.json
+++ b/src/i18n/locales/ru/universal.json
@@ -96,7 +96,8 @@
       "completed": "Завершено",
       "failed": "Ошибка",
       "failedHint": "Смотрите страницу Журналов для подробностей",
-      "retrying": "Попытка {{current}}/{{total}} через {{seconds}}с"
+      "retrying": "Попытка {{current}}/{{total}} через {{seconds}}с",
+      "muxing": "Сведение"
     },
     "summarize": "Сводка",
     "fetchingTranscript": "Получение транскрипции...",

--- a/src/i18n/locales/vi/download.json
+++ b/src/i18n/locales/vi/download.json
@@ -130,7 +130,8 @@
       "completed": "Hoàn thành",
       "failed": "Thất bại",
       "failedHint": "Xem trang Logs để biết chi tiết",
-      "retrying": "Thử lại {{current}}/{{total}} sau {{seconds}}s"
+      "retrying": "Thử lại {{current}}/{{total}} sau {{seconds}}s",
+      "muxing": "Đang ghép"
     },
     "summarize": "Tóm tắt",
     "openFolder": "Mở vị trí file",

--- a/src/i18n/locales/vi/universal.json
+++ b/src/i18n/locales/vi/universal.json
@@ -96,7 +96,8 @@
       "completed": "Hoàn thành",
       "failed": "Thất bại",
       "failedHint": "Xem trang Logs để biết chi tiết",
-      "retrying": "Thử lại {{current}}/{{total}} sau {{seconds}}s"
+      "retrying": "Thử lại {{current}}/{{total}} sau {{seconds}}s",
+      "muxing": "Đang ghép"
     },
     "summarize": "Tóm tắt",
     "openFolder": "Mở vị trí file",

--- a/src/i18n/locales/zh-CN/download.json
+++ b/src/i18n/locales/zh-CN/download.json
@@ -130,7 +130,8 @@
       "completed": "已完成",
       "failed": "失败",
       "failedHint": "查看日志页面了解详情",
-      "retrying": "{{seconds}}秒后重试 {{current}}/{{total}}"
+      "retrying": "{{seconds}}秒后重试 {{current}}/{{total}}",
+      "muxing": "合并中"
     },
     "summarize": "摘要",
     "openFolder": "打开所在文件夹",

--- a/src/i18n/locales/zh-CN/universal.json
+++ b/src/i18n/locales/zh-CN/universal.json
@@ -96,7 +96,8 @@
       "completed": "已完成",
       "failed": "失败",
       "failedHint": "查看日志页面了解详情",
-      "retrying": "{{seconds}}秒后重试 {{current}}/{{total}}"
+      "retrying": "{{seconds}}秒后重试 {{current}}/{{total}}",
+      "muxing": "合并中"
     },
     "summarize": "摘要",
     "openFolder": "打开所在文件夹",

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -100,8 +100,9 @@ export interface DownloadItem {
   error?: string;
   isPlaylist?: boolean;
   isLive?: boolean; // true if video is currently live streaming
-  downloadedSize?: string; // For live streams: "2.87 MiB"
-  elapsedTime?: string; // For live streams: "00:00:07"
+  isMuxing?: boolean; // true during ffmpeg mux/merge phase (e.g. --download-sections)
+  downloadedSize?: string; // For live/muxing: current output size
+  elapsedTime?: string; // For live/muxing: elapsed time
   playlistIndex?: number;
   playlistTotal?: number;
   thumbnail?: string;


### PR DESCRIPTION
Supersedes #44, which was closed due to CI formatting failures.

Rebased on current `develop`, all pre-commit checks passing (biome, tsc, cargo check). Addresses both Codex review findings from #44:
- Muxing label now localized via i18n keys across all 6 locales
- Sidecar placeholder creation gated to debug profile only

---

## Problem

Binary path resolution in `ffmpeg.rs`, `ytdlp.rs`, and `deno.rs` checks hardcoded paths (`/opt/homebrew/bin`, `/usr/local/bin`, `/usr/bin`) before `$PATH` entries. This causes the app to miss binaries provided by Nix, Homebrew, or other package managers that express their binaries through PATH. On macOS, GUI apps launched from Finder don't inherit the user's shell PATH, making the hardcoded fallbacks essential — but they should be fallbacks, not the primary resolution mechanism.

**Expected:** The app resolves yt-dlp, ffmpeg, and deno from the user's PATH first, then falls back to well-known locations.
**Actual:** Hardcoded paths win over PATH entries. A stale or missing binary at `/usr/local/bin/ffmpeg` shadows a working one in PATH (see #42).

Additionally:

- The yt-dlp sidecar placeholder created by `build.rs` for dev builds (a 22-byte shell stub) is returned as a valid bundled binary by `get_bundled_ytdlp_path()`, causing silent failures at runtime.
- `deno.rs` checks `~/.deno/bin/deno` (curl installer location) before `which deno`, so a system-provided deno on PATH is shadowed by a stale home-dir install.
- During `--download-sections` downloads, yt-dlp delegates the mux/merge to ffmpeg. The progress parser only handles `[download] X%` lines — ffmpeg stderr progress (`time=`, `speed=`, `Lsize=`) is ignored, leaving the progress bar stuck at 0%.
- `UniversalQueueItem` has no YouTube thumbnail fallback. When metadata fetch fails, the queue shows a blank grey placeholder instead of the readily available `img.youtube.com` thumbnail.
- Firefox profile selection returns profiles in file order. The active profile (where cookies live) is often not first, causing `--cookies-from-browser firefox:<profile>` to target the wrong profile.

## Fix

**Binary path resolution** (`ffmpeg.rs`, `ytdlp.rs`, `deno.rs`)
- Reorder `get_system_binary_candidates()` to iterate `$PATH` entries first, then append well-known fallback paths with deduplication
- Reorder `get_deno_path()` and `check_deno_internal()`: `which`/`where` (PATH) before `~/.deno/bin/deno` fallback

**Dev build sidecar** (`build.rs`, `ytdlp.rs`)
- `build.rs` creates a minimal placeholder so `tauri_build::build()` passes externalBin validation without a real per-platform binary — **gated to debug profile only** so release builds fail fast when the CI-provided binary is absent
- `get_bundled_ytdlp_path()` rejects files under 1024 bytes as placeholders
- `get_ytdlp_path()` falls through to system PATH as last resort in Auto mode

**FFmpeg mux progress** (`progress.rs`, `download.rs`, `types.ts`, contexts, queue components)
- Add `parse_ffmpeg_progress()` matching ffmpeg stderr lines containing `time=HH:MM:SS`, `speed=Nx`, `Lsize=`
- `download.rs` stderr task emits `download-progress` with `status="muxing"` when `parse_progress()` returns None and `parse_ffmpeg_progress()` matches
- Add `isMuxing` field to `DownloadItem` — set in `DownloadContext.tsx` and `UniversalContext.tsx` without overriding `isLive`
- `QueueItem.tsx` and `UniversalQueueItem.tsx` render an indeterminate shimmer bar with localized muxing label, elapsed time, and speed when `isMuxing && progress === 0`

**YouTube thumbnail fallback** (`UniversalQueueItem.tsx`)
- Add `getYouTubeVideoId()` at module level extracting video ID from YouTube URLs
- `thumbnailUrl` falls back to `img.youtube.com/vi/{id}/mqdefault.jpg` when `item.thumbnail` is null or errored
- `useEffect` resets `thumbError` on `item.thumbnail` change to prevent stale error state

**Firefox profile sorting** (`dependencies.rs`)
- Add `parse_firefox_profiles()` parsing `profiles.ini` `[Install*]` section `Default=` to identify the active profile path
- Sort profiles with active profile first, then alphabetical
- Replaces inline `Name=` line scanning on all three platforms (macOS, Windows, Linux)

**i18n** (all 6 locales × 2 namespaces)
- Add `queue.status.muxing` translation key to `download.json` and `universal.json` for en, vi, zh-CN, fr, pt, ru

## Test plan

- [ ] yt-dlp, ffmpeg, deno resolve from PATH in Nix devshell
- [ ] Dev build compiles without real yt-dlp sidecar binary
- [ ] Release build without sidecar fails at `tauri_build::build()`
- [ ] Download video with `--download-sections` — muxing shimmer bar displays with elapsed time and speed
- [ ] Paste YouTube URL in Universal queue — thumbnail fallback renders from `img.youtube.com`
- [ ] Firefox cookie profile shows active profile first

Fixes #42