### PR TITLE
Let native titlebar dragging handle double-click maximize

### DIFF
--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -122,12 +122,6 @@ export function MainLayout({ children, currentPage, onPageChange }: MainLayoutPr
             role="toolbar"
             data-tauri-drag-region
             className="flex-1 h-full"
-            onMouseDown={(e) => {
-              if (e.button === 0) {
-                e.preventDefault();
-                getCurrentWindow().startDragging();
-              }
-            }}
             onDoubleClick={() => getCurrentWindow().toggleMaximize()}
           />
           {/* Window controls — NOT inside the drag region */}


### PR DESCRIPTION
## Summary
- Remove the manual `startDragging()` call from the titlebar drag region.
- Keep native Tauri drag handling via `data-tauri-drag-region` and leave double-click to `toggleMaximize()`.

## Why
On Windows, the native drag region and manual `startDragging()` can fight the double-click maximize path: the window maximizes and then immediately restores back to windowed mode.

## Verification
- `bun run biome check --write .`
- `bun run tsc -b`
- `cargo check`

## Notes
This keeps the existing custom titlebar and window controls unchanged.