### PR TITLE
Find user-local Unix binaries during dependency lookup

### DIFF
--- a/src-tauri/src/services/deno.rs
+++ b/src-tauri/src/services/deno.rs
@@ -1,5 +1,7 @@
 use crate::types::DenoStatus;
-use crate::utils::{find_system_binary, unix_system_binary_dirs, CommandExt};
+#[cfg(not(windows))]
+use crate::utils::unix_system_binary_dirs;
+use crate::utils::{find_system_binary, CommandExt};
 use std::path::PathBuf;
 use std::process::Stdio;
 use tauri::{AppHandle, Manager};
@@ -11,14 +13,20 @@ fn get_system_deno_path() -> Option<PathBuf> {
     #[cfg(not(windows))]
     let binary_name = "deno";
 
-    let mut fallback_dirs = Vec::new();
-
-    #[cfg(not(windows))]
-    {
-        let home = std::env::var("HOME").unwrap_or_default();
-        fallback_dirs.push(PathBuf::from(home).join(".deno/bin"));
-        fallback_dirs.extend(unix_system_binary_dirs());
-    }
+    let fallback_dirs = {
+        #[cfg(windows)]
+        {
+            Vec::new()
+        }
+        #[cfg(not(windows))]
+        {
+            let mut dirs = Vec::new();
+            let home = std::env::var("HOME").unwrap_or_default();
+            dirs.push(PathBuf::from(home).join(".deno/bin"));
+            dirs.extend(unix_system_binary_dirs());
+            dirs
+        }
+    };
 
     find_system_binary(binary_name, &fallback_dirs)
 }

--- a/src-tauri/src/utils/command.rs
+++ b/src-tauri/src/utils/command.rs
@@ -18,7 +18,6 @@ pub trait CommandExt {
 impl CommandExt for Command {
     #[cfg(windows)]
     fn hide_window(&mut self) -> &mut Self {
-        use std::os::windows::process::CommandExt as WinCommandExt;
         self.creation_flags(CREATE_NO_WINDOW);
         self
     }
@@ -33,7 +32,7 @@ impl CommandExt for Command {
 impl CommandExt for std::process::Command {
     #[cfg(windows)]
     fn hide_window(&mut self) -> &mut Self {
-        use std::os::windows::process::CommandExt as WinCommandExt;
+        use std::os::windows::process::CommandExt as _;
         self.creation_flags(CREATE_NO_WINDOW);
         self
     }

--- a/src-tauri/src/utils/path.rs
+++ b/src-tauri/src/utils/path.rs
@@ -96,11 +96,19 @@ pub fn unix_system_binary_dirs() -> Vec<PathBuf> {
     }
     #[cfg(not(windows))]
     {
-        vec![
+        let mut dirs = Vec::new();
+
+        if let Some(home) = std::env::var_os("HOME") {
+            dirs.push(PathBuf::from(home).join(".local").join("bin"));
+        }
+
+        dirs.extend([
             PathBuf::from("/opt/homebrew/bin"),
             PathBuf::from("/usr/local/bin"),
             PathBuf::from("/usr/bin"),
-        ]
+        ]);
+
+        dirs
     }
 }
 


### PR DESCRIPTION
## Summary
- Include `~/.local/bin` in Unix fallback dependency lookup paths.
- Keep Deno's extra `~/.deno/bin` lookup while reusing the shared Unix fallback list.
- Silence a Windows-only trait import warning by importing it as `_` where needed.

## Why
Many Linux and macOS users install CLI tools into `~/.local/bin`. GUI apps can miss that path depending on launch environment, so the shared fallback list should cover it before system locations.

## Verification
- `cargo fmt --check`
- `cargo test utils::path::tests --lib`
- `cargo check`

## Notes
This deliberately avoids larger dependency/packaging refactors and only changes the shared fallback search list.