### PR TITLE
Hide unavailable extension summary action

### DIFF
--- a/extensions/youwee-webext/src/popup.html
+++ b/extensions/youwee-webext/src/popup.html
@@ -387,6 +387,14 @@
         background: rgba(168, 85, 247, 0.18);
       }
 
+      .actions[data-summary-available='false'] .secondary {
+        grid-column: 1 / -1;
+      }
+
+      .actions[data-summary-available='false'] .summary {
+        display: none;
+      }
+
       .status {
         margin-top: 10px;
         border-radius: 14px;
@@ -502,7 +510,7 @@
         </div>
       </div>
 
-      <div class="actions">
+      <div class="actions" data-summary-available="false">
         <button id="downloadBtn" type="button" class="primary"></button>
         <button id="queueBtn" type="button" class="secondary"></button>
         <button id="summaryBtn" type="button" class="summary"></button>

--- a/extensions/youwee-webext/src/popup.js
+++ b/extensions/youwee-webext/src/popup.js
@@ -26,6 +26,7 @@
   const statusEl = document.getElementById('status');
   const madeWithPrefixEl = document.getElementById('madeWithPrefix');
   const madeWithByEl = document.getElementById('madeWithBy');
+  const actionsEl = document.querySelector('.actions');
   const downloadBtn = document.getElementById('downloadBtn');
   const queueBtn = document.getElementById('queueBtn');
   const summaryBtn = document.getElementById('summaryBtn');
@@ -322,6 +323,18 @@
     }
   }
 
+  function setSummaryAvailability(canSummarize) {
+    if (actionsEl) {
+      actionsEl.dataset.summaryAvailable = canSummarize ? 'true' : 'false';
+    }
+    summaryBtn.hidden = !canSummarize;
+    summaryBtn.disabled = !canSummarize;
+    summaryBtn.title = canSummarize
+      ? ''
+      : t('floatingSummaryUnavailable', 'Summary is available for YouTube videos');
+    summaryBtn.setAttribute('aria-hidden', canSummarize ? 'false' : 'true');
+  }
+
   function setMediaValue(nextMedia, skipQualitySync = false) {
     mediaMode = ext.normalizeMedia(nextMedia);
     updateMediaToggleUi();
@@ -400,8 +413,7 @@
       setStatus(t('popupStatusInvalid', 'This tab cannot be sent to Youwee.'), 'error');
       downloadBtn.disabled = true;
       queueBtn.disabled = true;
-      summaryBtn.disabled = true;
-      summaryBtn.title = '';
+      setSummaryAvailability(false);
       copyUrlIconBtn.disabled = true;
       if (mediaVideoBtn) mediaVideoBtn.disabled = true;
       if (mediaAudioBtn) mediaAudioBtn.disabled = true;
@@ -414,10 +426,7 @@
     urlValueEl.textContent = currentUrl;
     downloadBtn.disabled = false;
     queueBtn.disabled = false;
-    summaryBtn.disabled = !canSummarize;
-    summaryBtn.title = canSummarize
-      ? ''
-      : t('floatingSummaryUnavailable', 'Summary is available for YouTube videos');
+    setSummaryAvailability(canSummarize);
     copyUrlIconBtn.disabled = false;
     if (mediaVideoBtn) mediaVideoBtn.disabled = false;
     if (mediaAudioBtn) mediaAudioBtn.disabled = false;


### PR DESCRIPTION
## Summary
- hide the AI Summary popup action when the current tab is not a YouTube URL
- let Add to queue fill the secondary action row when Summary is unavailable
- keep the existing active-tab Summary routing unchanged

## Tests
- bun run biome check --write .
- bun run tsc -b
- cargo check
- bun run ext:build