### PR TITLE
fix(ui): show-in-folder button does nothing on macOS

### DIFF
--- a/src-tauri/src/commands/history.rs
+++ b/src-tauri/src/commands/history.rs
@@ -3,15 +3,14 @@ use std::path::{Path, PathBuf};
 use crate::database::{
     add_history_internal, add_history_with_summary, assign_history_collections_in_db,
     assign_history_tags_in_db, clear_history_from_db, create_collection_in_db,
-    delete_collection_from_db, delete_history_from_db, find_duplicate_downloads_in_history_db,
-    get_collections_from_db, get_history_count_from_db, get_history_entries_by_ids_from_db,
-    get_history_from_db, get_tags_from_db, remove_history_from_collection_in_db,
-    remove_history_tag_from_db, rename_collection_in_db, update_history_filepath_and_title,
+    delete_collection_from_db, delete_history_from_db, get_collections_from_db,
+    get_history_count_from_db, get_history_entries_by_ids_from_db, get_history_from_db,
+    get_tags_from_db, remove_history_from_collection_in_db, remove_history_tag_from_db,
+    rename_collection_in_db, update_history_filepath_and_title,
     update_history_filepath_and_title_by_id, update_history_summary,
 };
 use crate::types::{
-    DownloadDuplicateIdentity, DownloadDuplicateMatch, HistoryAdvancedFilters, HistoryCollection,
-    HistoryEntry, HistorySort, HistoryTag,
+    HistoryAdvancedFilters, HistoryCollection, HistoryEntry, HistorySort, HistoryTag,
 };
 
 #[tauri::command]
@@ -67,43 +66,8 @@ pub fn get_history_entries_by_ids(ids: Vec<String>) -> Result<Vec<HistoryEntry>,
 }
 
 #[tauri::command]
-pub fn find_duplicate_downloads(
-    identities: Vec<DownloadDuplicateIdentity>,
-) -> Result<Vec<DownloadDuplicateMatch>, String> {
-    find_duplicate_downloads_in_history_db(identities)
-}
-
-#[tauri::command]
-pub fn delete_history(id: String, delete_file: Option<bool>) -> Result<(), String> {
-    if delete_file.unwrap_or(false) {
-        let entry = get_history_entries_by_ids_from_db(vec![id.clone()])?
-            .into_iter()
-            .next()
-            .ok_or_else(|| "History entry not found".to_string())?;
-        delete_history_media_file(&entry.filepath)?;
-    }
-
+pub fn delete_history(id: String) -> Result<(), String> {
     delete_history_from_db(id)
-}
-
-fn delete_history_media_file(filepath: &str) -> Result<(), String> {
-    let trimmed = filepath.trim();
-    if trimmed.is_empty() {
-        return Ok(());
-    }
-
-    let path = Path::new(trimmed);
-    if !path.exists() {
-        return Ok(());
-    }
-
-    let metadata = std::fs::symlink_metadata(path)
-        .map_err(|e| format!("Failed to inspect media file before deleting: {}", e))?;
-    if metadata.is_dir() {
-        return Err("Refusing to delete a directory from Library item deletion".to_string());
-    }
-
-    std::fs::remove_file(path).map_err(|e| format!("Failed to delete media file: {}", e))
 }
 
 #[tauri::command]
@@ -423,38 +387,6 @@ mod tests {
             std::env::temp_dir().join(format!("youwee-missing-{}.mp4", uuid::Uuid::new_v4()));
         let err = build_renamed_path(&missing, "new").expect_err("expected missing file error");
         assert!(err.contains("File not found"));
-    }
-
-    #[test]
-    fn delete_history_media_file_removes_regular_file() {
-        let file = make_temp_file("video.mp4");
-
-        delete_history_media_file(file.to_str().expect("utf8 path")).expect("delete media file");
-
-        assert!(!file.exists());
-        let _ = fs::remove_dir_all(file.parent().unwrap_or_else(|| Path::new("/")));
-    }
-
-    #[test]
-    fn delete_history_media_file_ignores_missing_file() {
-        let missing =
-            std::env::temp_dir().join(format!("youwee-missing-{}.mp4", uuid::Uuid::new_v4()));
-
-        delete_history_media_file(missing.to_str().expect("utf8 path"))
-            .expect("missing media file should not fail");
-    }
-
-    #[test]
-    fn delete_history_media_file_rejects_directory() {
-        let dir =
-            std::env::temp_dir().join(format!("youwee-history-test-{}", uuid::Uuid::new_v4()));
-        fs::create_dir_all(&dir).expect("create temp dir");
-
-        let error =
-            delete_history_media_file(dir.to_str().expect("utf8 path")).expect_err("reject dir");
-
-        assert!(error.contains("Refusing to delete a directory"));
-        let _ = fs::remove_dir_all(&dir);
     }
 
     fn ensure_test_history_table() {

--- a/src/components/download/GalleryQueueItem.tsx
+++ b/src/components/download/GalleryQueueItem.tsx
@@ -1,4 +1,4 @@
-import { revealItemInDir } from '@tauri-apps/plugin-opener';
+import { invoke } from '@tauri-apps/api/core';
 import { CheckCircle2, Clock, FolderOpen, Globe, Loader2, X, XCircle } from 'lucide-react';
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -27,7 +27,7 @@ export function GalleryQueueItem({
   const handleOpenFolder = useCallback(async () => {
     if (!item.completedFilepath) return;
     try {
-      await revealItemInDir(item.completedFilepath);
+      await invoke('open_file_location', { filepath: item.completedFilepath });
     } catch (error) {
       console.error('Failed to open gallery output folder:', error);
     }

--- a/src/components/download/QueueItem.tsx
+++ b/src/components/download/QueueItem.tsx
@@ -1,9 +1,8 @@
-import { revealItemInDir } from '@tauri-apps/plugin-opener';
+import { invoke } from '@tauri-apps/api/core';
 import {
   CheckCircle2,
   ChevronDown,
   ChevronUp,
-  CircleSlash,
   Clock,
   FolderOpen,
   HardDrive,
@@ -12,6 +11,7 @@ import {
   Loader2,
   MonitorPlay,
   Pencil,
+  Play,
   RefreshCw,
   Scissors,
   Sparkles,
@@ -20,14 +20,10 @@ import {
 } from 'lucide-react';
 import { type ChangeEvent, useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { SchedulePopover } from '@/components/download/SchedulePopover';
 import { SimpleMarkdown } from '@/components/ui/simple-markdown';
 import { useAI } from '@/contexts/AIContext';
-import type { ScheduleConfig } from '@/hooks/useSchedule';
 import type { DownloadItem, ItemDownloadSettings } from '@/lib/types';
 import { cn } from '@/lib/utils';
-import { extractYouTubeVideoId, youtubeThumbnailUrl } from '@/lib/youtube-url';
-import { ThumbnailCompletedBadge, ThumbnailFailedBadge } from './ThumbnailStatusBadge';
 
 // Parse a duration string like "5:30" or "1:05:30" to total seconds
 function parseDurationString(dur: string): number {
@@ -97,11 +93,6 @@ function formatQuality(quality: string): string {
   return qualityMap[quality] || quality;
 }
 
-function getFolderName(path: string): string {
-  const segments = path.split(/[\\/]/).filter(Boolean);
-  return segments.at(-1) || path;
-}
-
 interface QueueItemProps {
   item: DownloadItem;
   isFocused?: boolean;
@@ -109,9 +100,7 @@ interface QueueItemProps {
   disabled?: boolean;
   onRemove: (id: string) => void;
   onUpdateTimeRange: (id: string, start?: string, end?: string) => void;
-  onSelectOutputFolder: (id: string) => Promise<void>;
   onRename: (id: string, newName: string) => Promise<void>;
-  onScheduleUpcomingLive?: (config: ScheduleConfig) => void;
 }
 
 export function QueueItem({
@@ -121,9 +110,7 @@ export function QueueItem({
   disabled,
   onRemove,
   onUpdateTimeRange,
-  onSelectOutputFolder,
   onRename,
-  onScheduleUpcomingLive,
 }: QueueItemProps) {
   const { t } = useTranslation('download');
   const ai = useAI();
@@ -150,6 +137,12 @@ export function QueueItem({
   const generatingStatus =
     task?.status === 'fetching' ? 'fetching' : task?.status === 'generating' ? 'generating' : null;
 
+  // Extract video ID for thumbnail
+  const getVideoId = (url: string) => {
+    const match = url.match(/(?:youtube\.com\/watch\?v=|youtu\.be\/)([^&?]+)/);
+    return match ? match[1] : null;
+  };
+
   const handleGenerateSummary = () => {
     if (isGenerating) return;
 
@@ -168,23 +161,20 @@ export function QueueItem({
     });
   };
 
-  const videoId = extractYouTubeVideoId(item.url);
-  const thumbnailUrl = item.thumbnail || (videoId ? youtubeThumbnailUrl(videoId) : null);
+  const videoId = getVideoId(item.url);
+  const thumbnailUrl =
+    item.thumbnail || (videoId ? `https://img.youtube.com/vi/${videoId}/mqdefault.jpg` : null);
 
   const isActive = item.status === 'downloading' || item.status === 'fetching';
   const isCompleted = item.status === 'completed';
   const isError = item.status === 'error';
   const isPending = item.status === 'pending';
-  const isSkipped = item.status === 'skipped';
   const retryState = item.retryState;
-  const isUpcomingLiveError = item.errorCode === 'YT_UPCOMING_LIVE';
 
   // Get saved settings for pending items
   const itemSettings = item.settings as ItemDownloadSettings | undefined;
 
   const hasTimeRange = !!(itemSettings?.timeRangeStart && itemSettings?.timeRangeEnd);
-  const outputPath = itemSettings?.outputPath ?? '';
-  const outputFolderName = outputPath ? getFolderName(outputPath) : '';
 
   const handleApplyTimeRange = useCallback(() => {
     if (timeStart && timeEnd) {
@@ -211,10 +201,6 @@ export function QueueItem({
     });
   }, [itemSettings?.timeRangeStart, itemSettings?.timeRangeEnd]);
 
-  const handleSelectOutputFolder = useCallback(() => {
-    void onSelectOutputFolder(item.id);
-  }, [item.id, onSelectOutputFolder]);
-
   const handleTimeStartChange = useCallback((e: ChangeEvent<HTMLInputElement>) => {
     setTimeStart(autoFormatTimeInput(e.target.value));
   }, []);
@@ -233,7 +219,7 @@ export function QueueItem({
     if (!item.completedFilepath) return;
 
     try {
-      await revealItemInDir(item.completedFilepath);
+      await invoke('open_file_location', { filepath: item.completedFilepath });
     } catch (error) {
       console.error('Failed to open completed file location:', error);
     }
@@ -296,7 +282,7 @@ export function QueueItem({
             alt=""
             className={cn(
               'w-full h-full object-cover transition-all duration-300',
-              isCompleted && 'brightness-90 saturate-95',
+              isCompleted && 'opacity-60',
             )}
             loading="lazy"
             referrerPolicy="no-referrer"
@@ -371,10 +357,31 @@ export function QueueItem({
         )}
 
         {/* Completed Overlay */}
-        {isCompleted && <ThumbnailCompletedBadge />}
+        {isCompleted && (
+          <div className="absolute inset-0 bg-black/40 flex items-center justify-center">
+            <div className="w-10 h-10 rounded-full bg-emerald-500 flex items-center justify-center shadow-lg">
+              <CheckCircle2 className="w-6 h-6 text-white" />
+            </div>
+          </div>
+        )}
 
         {/* Error Overlay */}
-        {isError && <ThumbnailFailedBadge />}
+        {isError && (
+          <div className="absolute inset-0 bg-black/40 flex items-center justify-center">
+            <div className="w-10 h-10 rounded-full bg-red-500 flex items-center justify-center shadow-lg">
+              <XCircle className="w-6 h-6 text-white" />
+            </div>
+          </div>
+        )}
+
+        {/* Pending Overlay */}
+        {isPending && (
+          <div className="absolute inset-0 bg-black/30 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity">
+            <div className="w-10 h-10 rounded-full bg-white/90 flex items-center justify-center shadow-lg">
+              <Play className="w-5 h-5 text-black ml-0.5" />
+            </div>
+          </div>
+        )}
 
         {/* Playlist Badge */}
         {item.isPlaylist && showPlaylistBadge && (
@@ -423,14 +430,12 @@ export function QueueItem({
               isActive && 'bg-primary/10 text-primary',
               isCompleted && 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-400',
               isError && 'bg-red-500/10 text-red-600 dark:text-red-400',
-              isSkipped && 'bg-amber-500/10 text-amber-600 dark:text-amber-400',
             )}
           >
             {isPending && <Clock className="w-3 h-3" />}
             {isActive && <Loader2 className="w-3 h-3 animate-spin" />}
             {isCompleted && <CheckCircle2 className="w-3 h-3" />}
             {isError && <XCircle className="w-3 h-3" />}
-            {isSkipped && <CircleSlash className="w-3 h-3" />}
             <span>
               {isPending && t('queue.status.pending')}
               {isActive &&
@@ -439,7 +444,6 @@ export function QueueItem({
                   : t('queue.status.downloading'))}
               {isCompleted && t('queue.status.completed')}
               {isError && t('queue.status.failed')}
-              {isSkipped && t('queue.status.skipped')}
             </span>
           </span>
 
@@ -509,18 +513,8 @@ export function QueueItem({
           {isError && (
             <span className="inline-flex items-center gap-1 text-[10px] text-muted-foreground/70">
               <Lightbulb className="w-3 h-3" />
-              {isUpcomingLiveError ? t('queue.upcomingLive.hint') : t('queue.status.failedHint')}
+              {t('queue.status.failedHint')}
             </span>
-          )}
-
-          {isUpcomingLiveError && onScheduleUpcomingLive && (
-            <SchedulePopover
-              onSchedule={onScheduleUpcomingLive}
-              ns="download"
-              triggerVariant="inline"
-              triggerLabel={t('queue.upcomingLive.schedule')}
-              triggerClassName="border-muted-foreground/30 bg-transparent text-muted-foreground hover:border-muted-foreground/50 hover:bg-muted/50 hover:text-foreground"
-            />
           )}
 
           {/* Generating Status (inline with info badges) */}
@@ -535,27 +529,8 @@ export function QueueItem({
         </div>
 
         {/* Actions Row — interactive buttons, visually distinct */}
-        {!isActive && (
-          <div className="flex items-center gap-1.5 mt-1.5 flex-wrap">
-            {itemSettings && (isPending || isError) && (
-              <button
-                type="button"
-                onClick={handleSelectOutputFolder}
-                disabled={disabled}
-                title={
-                  outputPath
-                    ? t('queue.outputFolder', { path: outputPath })
-                    : t('queue.changeOutputFolder')
-                }
-                className="inline-flex max-w-[180px] items-center gap-1 text-[11px] px-2 py-0.5 rounded-md border border-dashed border-blue-500/30 text-blue-600 dark:text-blue-400 hover:border-blue-500/50 hover:bg-blue-500/10 transition-colors font-medium disabled:opacity-50 disabled:cursor-not-allowed"
-              >
-                <FolderOpen className="w-3 h-3 flex-shrink-0" />
-                <span className="truncate">
-                  {outputFolderName || t('queue.changeOutputFolder')}
-                </span>
-              </button>
-            )}
-
+        {!isActive && !isError && (
+          <div className="flex items-center gap-1.5 mt-1 flex-wrap">
             {/* Time Range button (only when pending) */}
             {isPending && itemSettings && (
               <button
@@ -576,14 +551,14 @@ export function QueueItem({
             )}
 
             {/* AI Summarize Button */}
-            {aiEnabled && !isError && !summary && !isGenerating && !summaryError && (
+            {aiEnabled && !summary && !isGenerating && !summaryError && (
               <button
                 type="button"
                 onClick={handleGenerateSummary}
-                className="inline-flex items-center gap-1 text-[11px] px-2 py-0.5 rounded-md border border-dashed border-[hsl(var(--gradient-via)/0.35)] bg-[linear-gradient(135deg,hsl(var(--gradient-from)/0.08),hsl(var(--gradient-via)/0.08),hsl(var(--gradient-to)/0.08))] hover:border-[hsl(var(--gradient-via)/0.55)] hover:bg-[linear-gradient(135deg,hsl(var(--gradient-from)/0.13),hsl(var(--gradient-via)/0.13),hsl(var(--gradient-to)/0.13))] transition-colors font-medium"
+                className="inline-flex items-center gap-1 text-[11px] px-2 py-0.5 rounded-md border border-dashed border-purple-500/30 text-purple-600 dark:text-purple-400 hover:border-purple-500/50 hover:bg-purple-500/10 transition-colors font-medium"
               >
-                <Sparkles className="w-3 h-3 text-[hsl(var(--gradient-via))]" />
-                <span className="gradient-text">{t('queue.summarize')}</span>
+                <Sparkles className="w-3 h-3" />
+                {t('queue.summarize')}
               </button>
             )}
 

--- a/src/components/download/UniversalQueueItem.tsx
+++ b/src/components/download/UniversalQueueItem.tsx
@@ -1,9 +1,8 @@
-import { revealItemInDir } from '@tauri-apps/plugin-opener';
+import { invoke } from '@tauri-apps/api/core';
 import {
   CheckCircle2,
   ChevronDown,
   ChevronUp,
-  CircleSlash,
   Clock,
   FolderOpen,
   Globe,
@@ -12,6 +11,7 @@ import {
   Loader2,
   MonitorPlay,
   Pencil,
+  Play,
   RefreshCw,
   Scissors,
   Sparkles,
@@ -20,14 +20,11 @@ import {
 } from 'lucide-react';
 import { type ChangeEvent, useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { SchedulePopover } from '@/components/download/SchedulePopover';
 import { SimpleMarkdown } from '@/components/ui/simple-markdown';
 import { useAI } from '@/contexts/AIContext';
-import type { ScheduleConfig } from '@/hooks/useSchedule';
 import type { DownloadItem, ItemUniversalSettings } from '@/lib/types';
 import { cn } from '@/lib/utils';
 import { SourceBadge } from './SourceBadge';
-import { ThumbnailCompletedBadge, ThumbnailFailedBadge } from './ThumbnailStatusBadge';
 
 // Parse a duration string like "5:30" or "1:05:30" to total seconds
 function parseDurationString(dur: string): number {
@@ -97,20 +94,13 @@ function formatQuality(quality: string): string {
   return qualityMap[quality] || quality;
 }
 
-function getFolderName(path: string): string {
-  const segments = path.split(/[\\/]/).filter(Boolean);
-  return segments.at(-1) || path;
-}
-
 interface UniversalQueueItemProps {
   item: DownloadItem;
   isFocused?: boolean;
   disabled?: boolean;
   onRemove: (id: string) => void;
   onUpdateTimeRange: (id: string, start?: string, end?: string) => void;
-  onSelectOutputFolder: (id: string) => Promise<void>;
   onRename: (id: string, newName: string) => Promise<void>;
-  onScheduleUpcomingLive?: (config: ScheduleConfig) => void;
 }
 
 export function UniversalQueueItem({
@@ -119,9 +109,7 @@ export function UniversalQueueItem({
   disabled,
   onRemove,
   onUpdateTimeRange,
-  onSelectOutputFolder,
   onRename,
-  onScheduleUpcomingLive,
 }: UniversalQueueItemProps) {
   const { t } = useTranslation('universal');
   const ai = useAI();
@@ -156,17 +144,13 @@ export function UniversalQueueItem({
   const isCompleted = item.status === 'completed';
   const isError = item.status === 'error';
   const isPending = item.status === 'pending';
-  const isSkipped = item.status === 'skipped';
   const retryState = item.retryState;
   const isFetchingMeta = isPending && !item.thumbnail && item.title === item.url && !item.extractor;
-  const isUpcomingLiveError = item.errorCode === 'YT_UPCOMING_LIVE';
 
   // Get saved settings for pending items
   const itemSettings = item.settings as ItemUniversalSettings | undefined;
 
   const hasTimeRange = !!(itemSettings?.timeRangeStart && itemSettings?.timeRangeEnd);
-  const outputPath = itemSettings?.outputPath ?? '';
-  const outputFolderName = outputPath ? getFolderName(outputPath) : '';
 
   const handleApplyTimeRange = useCallback(() => {
     if (timeStart && timeEnd) {
@@ -193,10 +177,6 @@ export function UniversalQueueItem({
     });
   }, [itemSettings?.timeRangeStart, itemSettings?.timeRangeEnd]);
 
-  const handleSelectOutputFolder = useCallback(() => {
-    void onSelectOutputFolder(item.id);
-  }, [item.id, onSelectOutputFolder]);
-
   const handleTimeStartChange = useCallback((e: ChangeEvent<HTMLInputElement>) => {
     setTimeStart(autoFormatTimeInput(e.target.value));
   }, []);
@@ -215,7 +195,7 @@ export function UniversalQueueItem({
     if (!item.completedFilepath) return;
 
     try {
-      await revealItemInDir(item.completedFilepath);
+      await invoke('open_file_location', { filepath: item.completedFilepath });
     } catch (error) {
       console.error('Failed to open completed file location:', error);
     }
@@ -294,7 +274,7 @@ export function UniversalQueueItem({
             alt=""
             className={cn(
               'w-full h-full object-cover transition-all duration-300',
-              isCompleted && 'brightness-90 saturate-95',
+              isCompleted && 'opacity-60',
             )}
             loading="lazy"
             onError={handleThumbError}
@@ -374,10 +354,31 @@ export function UniversalQueueItem({
         )}
 
         {/* Completed Overlay */}
-        {isCompleted && <ThumbnailCompletedBadge />}
+        {isCompleted && (
+          <div className="absolute inset-0 bg-black/40 flex items-center justify-center">
+            <div className="w-10 h-10 rounded-full bg-emerald-500 flex items-center justify-center shadow-lg">
+              <CheckCircle2 className="w-6 h-6 text-white" />
+            </div>
+          </div>
+        )}
 
         {/* Error Overlay */}
-        {isError && <ThumbnailFailedBadge />}
+        {isError && (
+          <div className="absolute inset-0 bg-black/40 flex items-center justify-center">
+            <div className="w-10 h-10 rounded-full bg-red-500 flex items-center justify-center shadow-lg">
+              <XCircle className="w-6 h-6 text-white" />
+            </div>
+          </div>
+        )}
+
+        {/* Pending Overlay */}
+        {isPending && (
+          <div className="absolute inset-0 bg-black/30 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity">
+            <div className="w-10 h-10 rounded-full bg-white/90 flex items-center justify-center shadow-lg">
+              <Play className="w-5 h-5 text-black ml-0.5" />
+            </div>
+          </div>
+        )}
       </div>
 
       {/* Content */}
@@ -421,14 +422,12 @@ export function UniversalQueueItem({
               isActive && 'bg-primary/10 text-primary',
               isCompleted && 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-400',
               isError && 'bg-red-500/10 text-red-600 dark:text-red-400',
-              isSkipped && 'bg-amber-500/10 text-amber-600 dark:text-amber-400',
             )}
           >
             {isPending && <Clock className="w-3 h-3" />}
             {isActive && <Loader2 className="w-3 h-3 animate-spin" />}
             {isCompleted && <CheckCircle2 className="w-3 h-3" />}
             {isError && <XCircle className="w-3 h-3" />}
-            {isSkipped && <CircleSlash className="w-3 h-3" />}
             <span>
               {isPending && t('queue.status.pending')}
               {isActive &&
@@ -437,7 +436,6 @@ export function UniversalQueueItem({
                   : t('queue.status.downloading'))}
               {isCompleted && t('queue.status.completed')}
               {isError && t('queue.status.failed')}
-              {isSkipped && t('queue.status.skipped')}
             </span>
           </span>
 
@@ -507,18 +505,8 @@ export function UniversalQueueItem({
           {isError && (
             <span className="inline-flex items-center gap-1 text-[10px] text-muted-foreground/70">
               <Lightbulb className="w-3 h-3" />
-              {isUpcomingLiveError ? t('queue.upcomingLive.hint') : t('queue.status.failedHint')}
+              {t('queue.status.failedHint')}
             </span>
-          )}
-
-          {isUpcomingLiveError && onScheduleUpcomingLive && (
-            <SchedulePopover
-              onSchedule={onScheduleUpcomingLive}
-              ns="universal"
-              triggerVariant="inline"
-              triggerLabel={t('queue.upcomingLive.schedule')}
-              triggerClassName="border-muted-foreground/30 bg-transparent text-muted-foreground hover:border-muted-foreground/50 hover:bg-muted/50 hover:text-foreground"
-            />
           )}
 
           {/* Generating Status (inline with info badges) */}
@@ -533,27 +521,8 @@ export function UniversalQueueItem({
         </div>
 
         {/* Actions Row — interactive buttons, visually distinct */}
-        {!isActive && (
-          <div className="flex items-center gap-1.5 mt-1.5 flex-wrap">
-            {itemSettings && (isPending || isError) && (
-              <button
-                type="button"
-                onClick={handleSelectOutputFolder}
-                disabled={disabled}
-                title={
-                  outputPath
-                    ? t('queue.outputFolder', { path: outputPath })
-                    : t('queue.changeOutputFolder')
-                }
-                className="inline-flex max-w-[180px] items-center gap-1 text-[11px] px-2 py-0.5 rounded-md border border-dashed border-blue-500/30 text-blue-600 dark:text-blue-400 hover:border-blue-500/50 hover:bg-blue-500/10 transition-colors font-medium disabled:opacity-50 disabled:cursor-not-allowed"
-              >
-                <FolderOpen className="w-3 h-3 flex-shrink-0" />
-                <span className="truncate">
-                  {outputFolderName || t('queue.changeOutputFolder')}
-                </span>
-              </button>
-            )}
-
+        {!isActive && !isError && (
+          <div className="flex items-center gap-1.5 mt-1 flex-wrap">
             {/* Time Range button (only when pending) */}
             {isPending && itemSettings && (
               <button
@@ -574,14 +543,14 @@ export function UniversalQueueItem({
             )}
 
             {/* AI Summarize Button */}
-            {aiEnabled && !isError && !summary && !isGenerating && !summaryError && (
+            {aiEnabled && !summary && !isGenerating && !summaryError && (
               <button
                 type="button"
                 onClick={handleGenerateSummary}
-                className="inline-flex items-center gap-1 text-[11px] px-2 py-0.5 rounded-md border border-dashed border-[hsl(var(--gradient-via)/0.35)] bg-[linear-gradient(135deg,hsl(var(--gradient-from)/0.08),hsl(var(--gradient-via)/0.08),hsl(var(--gradient-to)/0.08))] hover:border-[hsl(var(--gradient-via)/0.55)] hover:bg-[linear-gradient(135deg,hsl(var(--gradient-from)/0.13),hsl(var(--gradient-via)/0.13),hsl(var(--gradient-to)/0.13))] transition-colors font-medium"
+                className="inline-flex items-center gap-1 text-[11px] px-2 py-0.5 rounded-md border border-dashed border-purple-500/30 text-purple-600 dark:text-purple-400 hover:border-purple-500/50 hover:bg-purple-500/10 transition-colors font-medium"
               >
-                <Sparkles className="w-3 h-3 text-[hsl(var(--gradient-via))]" />
-                <span className="gradient-text">{t('queue.summarize')}</span>
+                <Sparkles className="w-3 h-3" />
+                {t('queue.summarize')}
               </button>
             )}
 

--- a/src/components/processing/ChatPanel.tsx
+++ b/src/components/processing/ChatPanel.tsx
@@ -1,5 +1,5 @@
 import { open } from '@tauri-apps/plugin-dialog';
-import { revealItemInDir } from '@tauri-apps/plugin-opener';
+import { invoke } from '@tauri-apps/api/core';
 import {
   Check,
   FileText,
@@ -403,7 +403,7 @@ export function ChatPanel({
                     <button
                       type="button"
                       className="flex items-center gap-1 text-xs font-medium text-green-600 dark:text-green-400 hover:underline w-fit"
-                      onClick={() => msg.outputPath && revealItemInDir(msg.outputPath)}
+                      onClick={() => msg.outputPath && invoke('open_file_location', { filepath: msg.outputPath })}
                     >
                       <FolderOpen className="w-3 h-3" />
                       {t('processing.chat.openInFolder')}
@@ -756,7 +756,7 @@ export function ChatPanel({
                 'relative flex-shrink-0 h-10 w-10 rounded-xl flex items-center justify-center',
                 'transition-all duration-300 ease-out',
                 inputMessage.trim() && hasVideo && !isProcessing && !isGenerating
-                  ? 'btn-gradient shadow-lg shadow-primary/25 hover:shadow-xl hover:shadow-primary/30'
+                  ? 'btn-gradient shadow-lg shadow-primary/25 hover:shadow-xl hover:shadow-primary/30 hover:scale-105'
                   : 'bg-muted/50 text-muted-foreground/30 hover:bg-muted/70 hover:text-muted-foreground/50',
               )}
               onClick={handleSendMessage}

--- a/src/components/processing/HistoryDialog.tsx
+++ b/src/components/processing/HistoryDialog.tsx
@@ -1,4 +1,4 @@
-import { revealItemInDir } from '@tauri-apps/plugin-opener';
+import { invoke } from '@tauri-apps/api/core';
 import {
   AlertCircle,
   Calendar,
@@ -20,7 +20,6 @@ import {
 } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { EmptyStateIllustration } from '@/components/shared/EmptyStateIllustration';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
@@ -551,11 +550,13 @@ export function HistoryDialog({
               <div className="p-3 space-y-1">
                 {filteredHistory.length === 0 ? (
                   <div className="flex flex-col items-center justify-center py-12 text-center">
-                    <EmptyStateIllustration
-                      className="mb-4"
-                      icon={hasActiveFilters ? SlidersHorizontal : History}
-                      size="sm"
-                    />
+                    <div className="w-12 h-12 rounded-full bg-muted/50 flex items-center justify-center mb-3">
+                      {hasActiveFilters ? (
+                        <SlidersHorizontal className="w-6 h-6 text-muted-foreground/50" />
+                      ) : (
+                        <History className="w-6 h-6 text-muted-foreground/50" />
+                      )}
+                    </div>
                     <p className="text-sm text-muted-foreground">
                       {hasActiveFilters
                         ? t('processing.historyDialog.noResults')
@@ -620,7 +621,7 @@ export function HistoryDialog({
                         <Button
                           size="sm"
                           onClick={() =>
-                            selectedJob.output_path && revealItemInDir(selectedJob.output_path)
+                            selectedJob.output_path && invoke('open_file_location', { filepath: selectedJob.output_path })
                           }
                           className="gap-1.5"
                         >
@@ -751,7 +752,9 @@ export function HistoryDialog({
               </ScrollArea>
             ) : (
               <div className="flex-1 flex flex-col items-center justify-center text-center p-6">
-                <EmptyStateIllustration className="mb-5" icon={FileVideo} size="sm" />
+                <div className="w-16 h-16 rounded-full bg-muted/50 flex items-center justify-center mb-4">
+                  <FileVideo className="w-8 h-8 text-muted-foreground/50" />
+                </div>
                 <p className="text-muted-foreground">{t('processing.historyDialog.selectJob')}</p>
               </div>
             )}

--- a/src/contexts/ProcessingContext.tsx
+++ b/src/contexts/ProcessingContext.tsx
@@ -1,23 +1,1070 @@
-import { createContext, type ReactNode, useContext } from 'react';
+import { invoke } from '@tauri-apps/api/core';
+import { listen, type UnlistenFn } from '@tauri-apps/api/event';
+import { open } from '@tauri-apps/plugin-dialog';
+import { readFile } from '@tauri-apps/plugin-fs';
 import {
-  type PreviewConfirmInfo,
-  type ProcessingContextValue,
-  useProcessingController,
-} from './processing/useProcessingController';
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+import { toAssetUrl } from '@/lib/asset-access';
+import { localizeUnknownError } from '@/lib/backend-error';
+import type {
+  ChatAttachment,
+  ChatMessage,
+  FFmpegCommandResult,
+  ProcessingJob,
+  ProcessingPreset,
+  ProcessingProgress,
+  ProcessingStatus,
+  ProcessingTaskType,
+  TimelineSelection,
+  VideoMetadata,
+} from '@/lib/types';
+
+const PREVIEW_THRESHOLD_KEY = 'youwee-preview-size-threshold';
+const DEFAULT_PREVIEW_THRESHOLD_MB = 300;
+
+export interface PreviewConfirmInfo {
+  filename: string;
+  fileSizeMB: number;
+  codec: string;
+}
+
+interface ProcessingContextValue {
+  // Video state
+  videoPath: string | null;
+  videoSrc: string | null;
+  audioSrc: string | null;
+  thumbnailSrc: string | null;
+  videoMetadata: VideoMetadata | null;
+  isLoadingVideo: boolean;
+  isGeneratingPreview: boolean;
+  isUsingPreview: boolean;
+  videoError: string | null;
+  duration: number;
+
+  // Preview confirm dialog
+  pendingPreviewConfirm: PreviewConfirmInfo | null;
+  confirmPreview: (createPreview: boolean) => void;
+
+  // Settings
+  previewSizeThreshold: number;
+  setPreviewSizeThreshold: (mb: number) => void;
+
+  // Timeline
+  currentTime: number;
+  selection: TimelineSelection | null;
+
+  // Processing
+  status: ProcessingStatus;
+  isProcessing: boolean;
+  currentJob: ProcessingJob | null;
+  currentJobId: string | null;
+  progress: ProcessingProgress | null;
+  generatedCommand: FFmpegCommandResult | null;
+  completedOutputPath: string | null;
+
+  // Chat
+  messages: ChatMessage[];
+  isGenerating: boolean;
+  outputDirectory: string;
+
+  // Image attachments
+  attachedImages: ChatAttachment[];
+
+  // History & Presets
+  history: ProcessingJob[];
+  presets: ProcessingPreset[];
+
+  // Batch
+  batchFiles: string[];
+
+  // Actions
+  selectVideo: () => Promise<void>;
+  loadVideo: (path: string) => Promise<void>;
+  setVideoError: (error: string | null) => void;
+  setCurrentTime: (time: number) => void;
+  setDuration: (duration: number) => void;
+  setSelection: (selection: TimelineSelection | null) => void;
+  addMessage: (
+    role: 'user' | 'assistant' | 'system' | 'complete',
+    content: string,
+    options?: { command?: FFmpegCommandResult; outputPath?: string },
+  ) => void;
+
+  // AI Actions
+  sendMessage: (content: string) => Promise<void>;
+  selectOutputDirectory: () => Promise<void>;
+  generateCommand: (
+    taskType: ProcessingTaskType,
+    options?: Record<string, unknown>,
+  ) => Promise<void>;
+
+  // Image Actions
+  attachImages: (paths: string[]) => Promise<void>;
+  removeAttachment: (id: string) => void;
+  clearAttachments: () => void;
+
+  // Processing Actions
+  executeCommand: (command?: FFmpegCommandResult) => Promise<void>;
+  cancelProcessing: () => Promise<void>;
+  clearCommand: () => void;
+  openOutputFolder: () => Promise<void>;
+
+  // History Actions
+  loadHistory: () => Promise<void>;
+  deleteJob: (id: string) => Promise<void>;
+  clearHistory: () => Promise<void>;
+
+  // Preset Actions
+  loadPresets: () => Promise<void>;
+  savePreset: (name: string, description?: string) => Promise<void>;
+  deletePreset: (id: string) => Promise<void>;
+  applyPreset: (preset: ProcessingPreset) => Promise<void>;
+
+  // Batch Actions
+  addBatchFile: (path: string) => void;
+  removeBatchFile: (path: string) => void;
+  clearBatch: () => void;
+  processBatch: () => Promise<void>;
+
+  // Utils
+  reset: () => void;
+}
 
 const ProcessingContext = createContext<ProcessingContextValue | null>(null);
 
 export function ProcessingProvider({ children }: { children: ReactNode }) {
-  const value = useProcessingController();
-  return <ProcessingContext.Provider value={value}>{children}</ProcessingContext.Provider>;
+  // Video state
+  const [videoPath, setVideoPath] = useState<string | null>(null);
+  const [videoSrc, setVideoSrc] = useState<string | null>(null);
+  const [audioSrc, setAudioSrc] = useState<string | null>(null);
+  const [thumbnailSrc, setThumbnailSrc] = useState<string | null>(null);
+  const [videoMetadata, setVideoMetadata] = useState<VideoMetadata | null>(null);
+  const [isLoadingVideo, setIsLoadingVideo] = useState(false);
+  const [isGeneratingPreview, setIsGeneratingPreview] = useState(false);
+  const [isUsingPreview, setIsUsingPreview] = useState(false);
+  const [videoError, setVideoError] = useState<string | null>(null);
+  const [duration, setDuration] = useState(0);
+
+  // Timeline
+  const [currentTime, setCurrentTime] = useState(0);
+  const [selection, setSelection] = useState<TimelineSelection | null>(null);
+
+  // Processing
+  const [status, setStatus] = useState<ProcessingStatus>('idle');
+  const [isProcessing, setIsProcessing] = useState(false);
+  const [currentJob, setCurrentJob] = useState<ProcessingJob | null>(null);
+  const [currentJobId, setCurrentJobId] = useState<string | null>(null);
+  const [progress, setProgress] = useState<ProcessingProgress | null>(null);
+  const [generatedCommand, setGeneratedCommand] = useState<FFmpegCommandResult | null>(null);
+  const [completedOutputPath, setCompletedOutputPath] = useState<string | null>(null);
+
+  // Chat
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [outputDirectory, setOutputDirectory] = useState('');
+
+  // Image attachments
+  const [attachedImages, setAttachedImages] = useState<ChatAttachment[]>([]);
+
+  // History & Presets
+  const [history, setHistory] = useState<ProcessingJob[]>([]);
+  const [presets, setPresets] = useState<ProcessingPreset[]>([]);
+
+  // Batch
+  const [batchFiles, setBatchFiles] = useState<string[]>([]);
+
+  // Preview confirm dialog
+  const [pendingPreviewConfirm, setPendingPreviewConfirm] = useState<PreviewConfirmInfo | null>(
+    null,
+  );
+  const previewConfirmResolverRef = useRef<((createPreview: boolean) => void) | null>(null);
+
+  // Settings
+  const [previewSizeThreshold, setPreviewSizeThresholdState] = useState<number>(() => {
+    try {
+      const saved = localStorage.getItem(PREVIEW_THRESHOLD_KEY);
+      if (saved) return Number(saved);
+    } catch (_e) {
+      // ignore
+    }
+    return DEFAULT_PREVIEW_THRESHOLD_MB;
+  });
+
+  const setPreviewSizeThreshold = useCallback((mb: number) => {
+    setPreviewSizeThresholdState(mb);
+    localStorage.setItem(PREVIEW_THRESHOLD_KEY, String(mb));
+  }, []);
+
+  // Confirm preview dialog: called by dialog buttons to resolve the pending promise
+  const confirmPreview = useCallback((createPreview: boolean) => {
+    previewConfirmResolverRef.current?.(createPreview);
+    previewConfirmResolverRef.current = null;
+    setPendingPreviewConfirm(null);
+  }, []);
+
+  // Helper: ask user whether to create preview for large files
+  const requestPreviewConfirm = useCallback((info: PreviewConfirmInfo): Promise<boolean> => {
+    return new Promise<boolean>((resolve) => {
+      previewConfirmResolverRef.current = resolve;
+      setPendingPreviewConfirm(info);
+    });
+  }, []);
+
+  // Refs
+  const unlistenRef = useRef<UnlistenFn | null>(null);
+
+  // Listen for processing progress events
+  useEffect(() => {
+    const setupListener = async () => {
+      unlistenRef.current = await listen<ProcessingProgress>('processing-progress', (event) => {
+        setProgress(event.payload);
+        if (event.payload.percent >= 100) {
+          setStatus('completed');
+          setIsProcessing(false);
+        }
+      });
+    };
+
+    setupListener();
+
+    return () => {
+      unlistenRef.current?.();
+    };
+  }, []);
+
+  // Helper: load video source URL
+  // Uses convertFileSrc (streaming via asset protocol) for standard codecs
+  const loadVideoSrc = useCallback(async (filePath: string): Promise<string> => {
+    return toAssetUrl(filePath);
+  }, []);
+
+  const getDirectoryFromPath = useCallback((filePath: string): string => {
+    const normalized = filePath.replace(/\\/g, '/');
+    const lastSlash = normalized.lastIndexOf('/');
+    if (lastSlash <= 0) return '';
+    return normalized.slice(0, lastSlash);
+  }, []);
+
+  // Helper: revoke previous blob URL to prevent memory leak
+  const revokePreviousVideoSrc = useCallback((src: string | null) => {
+    if (src?.startsWith('blob:')) {
+      URL.revokeObjectURL(src);
+    }
+  }, []);
+
+  // Add message to chat
+  const addMessage = useCallback(
+    (
+      role: 'user' | 'assistant' | 'system' | 'complete',
+      content: string,
+      options?: { command?: FFmpegCommandResult; outputPath?: string },
+    ) => {
+      setMessages((prev) => [
+        ...prev,
+        {
+          id: crypto.randomUUID(),
+          role,
+          content,
+          command: options?.command,
+          outputPath: options?.outputPath,
+          timestamp: new Date().toISOString(),
+        },
+      ]);
+    },
+    [],
+  );
+
+  // Load processing history - defined early so other functions can use it
+  const loadHistory = useCallback(async () => {
+    try {
+      const jobs = await invoke<ProcessingJob[]>('get_processing_history', { limit: 50 });
+      setHistory(jobs);
+    } catch (error) {
+      console.error('Failed to load history:', error);
+    }
+  }, []);
+
+  // Load video and get metadata
+  const loadVideo = useCallback(
+    async (path: string) => {
+      setIsLoadingVideo(true);
+      setVideoPath(path);
+      setOutputDirectory(getDirectoryFromPath(path));
+      // Revoke previous blob URL before clearing
+      revokePreviousVideoSrc(videoSrc);
+      revokePreviousVideoSrc(thumbnailSrc);
+      setVideoSrc(null);
+      setAudioSrc(null);
+      setThumbnailSrc(null);
+      setVideoError(null);
+      setSelection(null);
+      setCurrentTime(0);
+      setGeneratedCommand(null);
+      setMessages([]);
+      setCompletedOutputPath(null);
+      setIsUsingPreview(false);
+
+      try {
+        const metadata = await invoke<VideoMetadata>('get_video_metadata', { path });
+        setVideoMetadata(metadata);
+
+        // Determine if the video needs preview transcoding.
+        // WebKit (macOS WKWebView, Linux WebKitGTK) only supports MP4/MOV/M4V
+        // containers and a limited set of codecs natively.
+        const codec = metadata.video_codec.toLowerCase();
+        const format = metadata.format.toLowerCase();
+
+        // Check container: ffprobe returns e.g. "mov,mp4,m4a,3gp,3g2,mj2" for MP4
+        const supportedContainers = ['mp4', 'mov', 'm4v', 'm4a', '3gp'];
+        const hasUnsupportedContainer = !supportedContainers.some((c) => format.includes(c));
+
+        // Check codec: HEVC works natively on macOS (AVFoundation) but NOT on Linux (WebKitGTK)
+        const isMacOS = /Mac/.test(navigator.platform);
+        const problematicCodecs = isMacOS
+          ? ['vp9', 'vp8', 'av1', 'theora']
+          : ['vp9', 'vp8', 'av1', 'hevc', 'h265', 'theora'];
+        const hasProblematicCodec = problematicCodecs.some((c) => codec.includes(c));
+
+        const needsPreview = hasUnsupportedContainer || hasProblematicCodec;
+
+        const diagInfo = `codec=${metadata.video_codec}, container=${metadata.format}, needsPreview=${needsPreview}, platform=${isMacOS ? 'macOS' : 'other'}`;
+        console.warn(`[PROCESSING] ${diagInfo}`);
+        addMessage('system', `[DEV] ${diagInfo}`);
+
+        if (needsPreview) {
+          // Video cannot play natively in the webview — generate H.264 preview.
+          // Strategy: generate H.264 preview WITHOUT audio (-an) + separate WAV audio
+          // + thumbnail as fallback. Video and audio are played via separate elements
+          // and synced with JavaScript. If <video> still crashes, VideoPlayer
+          // auto-falls back to the static thumbnail.
+
+          // For large files, ask user whether to generate preview (costly in time/space)
+          const fileSizeMB = metadata.file_size / 1_000_000;
+          let shouldGeneratePreview = true;
+
+          if (previewSizeThreshold > 0 && fileSizeMB > previewSizeThreshold) {
+            // Stop showing loading spinner while waiting for user input
+            setIsLoadingVideo(false);
+            shouldGeneratePreview = await requestPreviewConfirm({
+              filename: metadata.filename,
+              fileSizeMB,
+              codec: metadata.video_codec,
+            });
+            setIsLoadingVideo(true);
+          }
+
+          if (shouldGeneratePreview) {
+            addMessage('system', `${metadata.filename} - Generating preview...`);
+            setIsGeneratingPreview(true);
+            try {
+              // Generate video preview (H.264 no audio), audio preview (WAV),
+              // and thumbnail (JPEG) in parallel
+              const [previewPath, audioPath, thumbPath] = await Promise.all([
+                invoke<string>('generate_video_preview', {
+                  inputPath: path,
+                  videoCodec: metadata.video_codec,
+                  containerFormat: metadata.format,
+                }),
+                metadata.has_audio
+                  ? invoke<string>('generate_audio_preview', { inputPath: path })
+                  : Promise.resolve(null),
+                invoke<string>('generate_video_thumbnail', {
+                  inputPath: path,
+                }),
+              ]);
+
+              // Load thumbnail as blob URL (fallback for when <video> fails)
+              const fileData = await readFile(thumbPath);
+              const blob = new Blob([fileData], { type: 'image/jpeg' });
+              const thumbUrl = URL.createObjectURL(blob);
+              setThumbnailSrc(thumbUrl);
+
+              // Load audio preview via asset protocol (streaming, no RAM copy)
+              if (audioPath) {
+                const audioSrcUrl = await loadVideoSrc(audioPath);
+                setAudioSrc(audioSrcUrl);
+              }
+
+              // Load H.264 no-audio preview via asset protocol
+              const previewSrcUrl = await loadVideoSrc(previewPath);
+              setVideoSrc(previewSrcUrl);
+              setIsUsingPreview(true);
+              console.warn(
+                `[PROCESSING] Preview loaded: video=${previewSrcUrl}, audio=${audioPath ? 'yes' : 'no'}`,
+              );
+              addMessage(
+                'system',
+                `${metadata.filename} loaded (preview mode — output will use original quality)`,
+              );
+            } catch (previewErr) {
+              // All generation failed — show error but allow FFmpeg usage
+              console.error('[PROCESSING] Preview generation failed:', previewErr);
+              setVideoError(
+                `Cannot preview this video (${metadata.video_codec} codec). ` +
+                  'Please make sure FFmpeg is installed. ' +
+                  'You can still process the file with FFmpeg commands below.',
+              );
+              addMessage(
+                'system',
+                `Preview generation failed: ${previewErr}. You can still apply FFmpeg commands to this file.`,
+              );
+            } finally {
+              setIsGeneratingPreview(false);
+            }
+          } else {
+            // User chose thumbnail-only mode for large file
+            addMessage('system', `${metadata.filename} - Generating thumbnail...`);
+            setIsGeneratingPreview(true);
+            try {
+              const thumbPath = await invoke<string>('generate_video_thumbnail', {
+                inputPath: path,
+              });
+              const fileData = await readFile(thumbPath);
+              const blob = new Blob([fileData], { type: 'image/jpeg' });
+              const thumbUrl = URL.createObjectURL(blob);
+              setThumbnailSrc(thumbUrl);
+              setIsUsingPreview(true);
+              addMessage(
+                'system',
+                `${metadata.filename} loaded (thumbnail only — output will use original quality)`,
+              );
+            } catch (thumbErr) {
+              setVideoError(
+                `Cannot preview this video (${metadata.video_codec} codec). ` +
+                  'Please make sure FFmpeg is installed. ' +
+                  'You can still process the file with FFmpeg commands below.',
+              );
+              addMessage(
+                'system',
+                `Thumbnail generation failed: ${thumbErr}. You can still apply FFmpeg commands to this file.`,
+              );
+            } finally {
+              setIsGeneratingPreview(false);
+            }
+          }
+        } else {
+          // Standard codec in supported container: stream directly via asset protocol
+          const videoSrcUrl = await loadVideoSrc(path);
+          setVideoSrc(videoSrcUrl);
+          console.warn(`[PROCESSING] Direct streaming: ${videoSrcUrl}`);
+          addMessage('system', `${metadata.filename} loaded`);
+        }
+      } catch (error) {
+        console.error('Failed to load video metadata:', error);
+        setVideoMetadata(null);
+        const localized = localizeUnknownError(error);
+        setVideoError(localized);
+        addMessage('system', `Error: ${localized}`);
+      } finally {
+        setIsLoadingVideo(false);
+      }
+    },
+    [
+      addMessage,
+      getDirectoryFromPath,
+      loadVideoSrc,
+      revokePreviousVideoSrc,
+      videoSrc,
+      thumbnailSrc,
+      previewSizeThreshold,
+      requestPreviewConfirm,
+    ],
+  );
+
+  // Select video file
+  const selectVideo = useCallback(async () => {
+    try {
+      const selected = await open({
+        multiple: false,
+        filters: [
+          {
+            name: 'Video',
+            extensions: ['mp4', 'mkv', 'webm', 'avi', 'mov', 'wmv', 'flv', 'm4v', 'ts', 'mts'],
+          },
+        ],
+      });
+
+      if (selected && typeof selected === 'string') {
+        await loadVideo(selected);
+      }
+    } catch (error) {
+      console.error('Failed to select video:', error);
+    }
+  }, [loadVideo]);
+
+  // Select output directory for processed files
+  const selectOutputDirectory = useCallback(async () => {
+    try {
+      const selected = await open({
+        directory: true,
+        multiple: false,
+        defaultPath: outputDirectory || (videoPath ? getDirectoryFromPath(videoPath) : undefined),
+      });
+
+      if (selected && typeof selected === 'string') {
+        setOutputDirectory(selected);
+      }
+    } catch (error) {
+      console.error('Failed to select output directory:', error);
+    }
+  }, [outputDirectory, videoPath, getDirectoryFromPath]);
+
+  // Media attachment interface from Rust
+  interface AttachmentInfoResult {
+    path: string;
+    filename: string;
+    kind: 'image' | 'video' | 'subtitle' | 'other';
+    width?: number;
+    height?: number;
+    size: number;
+    format: string;
+  }
+
+  // Attach files (image/video/subtitle) by file paths
+  const attachImages = useCallback(async (paths: string[]) => {
+    const newAttachments: ChatAttachment[] = [];
+
+    for (const path of paths) {
+      try {
+        const info = await invoke<AttachmentInfoResult>('get_processing_attachment_info', { path });
+        let previewUrl: string | undefined;
+
+        if (info.kind === 'image') {
+          // Read image as blob for preview
+          const fileData = await readFile(path);
+          const blob = new Blob([fileData]);
+          previewUrl = URL.createObjectURL(blob);
+        }
+
+        newAttachments.push({
+          id: crypto.randomUUID(),
+          path: info.path,
+          kind: info.kind,
+          name: info.filename,
+          width: info.width,
+          height: info.height,
+          size: info.size,
+          format: info.format,
+          previewUrl,
+        });
+      } catch (error) {
+        console.error(`Failed to attach file ${path}:`, error);
+      }
+    }
+
+    if (newAttachments.length > 0) {
+      setAttachedImages((prev) => [...prev, ...newAttachments]);
+    }
+  }, []);
+
+  // Remove a single attachment
+  const removeAttachment = useCallback((id: string) => {
+    setAttachedImages((prev) => {
+      const removed = prev.find((a) => a.id === id);
+      if (removed?.previewUrl) {
+        URL.revokeObjectURL(removed.previewUrl);
+      }
+      return prev.filter((a) => a.id !== id);
+    });
+  }, []);
+
+  // Clear all attachments
+  const clearAttachments = useCallback(() => {
+    setAttachedImages((prev) => {
+      for (const a of prev) {
+        if (a.previewUrl) {
+          URL.revokeObjectURL(a.previewUrl);
+        }
+      }
+      return [];
+    });
+  }, []);
+
+  // Send chat message and auto-execute
+  const sendMessage = useCallback(
+    async (content: string) => {
+      if (!videoMetadata || isGenerating || !videoPath) return;
+
+      // Capture current attachments before clearing
+      const currentAttachments = [...attachedImages];
+
+      // Add user message with attachments
+      const userMessage: ChatMessage = {
+        id: crypto.randomUUID(),
+        role: 'user',
+        content,
+        timestamp: new Date().toISOString(),
+        attachments: currentAttachments.length > 0 ? currentAttachments : undefined,
+      };
+      setMessages((prev) => [...prev, userMessage]);
+      setIsGenerating(true);
+      setStatus('generating');
+
+      // Clear attachments after capturing
+      if (currentAttachments.length > 0) {
+        setAttachedImages([]);
+      }
+
+      try {
+        // Build attachment info for backend
+        const attachmentInfos =
+          currentAttachments.length > 0
+            ? currentAttachments.map((a) => ({
+                path: a.path,
+                filename: a.name,
+                kind: a.kind,
+                width: a.width ?? null,
+                height: a.height ?? null,
+                size: a.size,
+                format: a.format,
+              }))
+            : null;
+
+        const result = await invoke<FFmpegCommandResult>('generate_processing_command', {
+          inputPath: videoPath,
+          userPrompt: content,
+          timelineStart: selection?.start ?? null,
+          timelineEnd: selection?.end ?? null,
+          metadata: videoMetadata,
+          attachments: attachmentInfos,
+          outputDir: outputDirectory || null,
+        });
+
+        // Add assistant message with explanation
+        const assistantMessage: ChatMessage = {
+          id: crypto.randomUUID(),
+          role: 'assistant',
+          content:
+            result.explanation +
+            (result.warnings.length > 0 ? `\n\n${result.warnings.join('\n')}` : ''),
+          timestamp: new Date().toISOString(),
+          command: result,
+        };
+        setMessages((prev) => [...prev, assistantMessage]);
+        setIsGenerating(false);
+
+        // Auto-execute the command
+        setStatus('processing');
+        setIsProcessing(true);
+        setProgress(null);
+        setCompletedOutputPath(null);
+
+        const jobId = crypto.randomUUID();
+        setCurrentJobId(jobId);
+
+        // Save job to history
+        await invoke('save_processing_job', {
+          id: jobId,
+          inputPath: videoPath,
+          outputPath: result.output_path,
+          taskType: 'custom',
+          userPrompt: content,
+          ffmpegCommand: result.command,
+        });
+
+        await invoke('execute_ffmpeg_command', {
+          jobId,
+          commandArgs: result.command_args,
+          inputPath: videoPath,
+          outputPath: result.output_path,
+        });
+
+        // Update job status
+        await invoke('update_processing_job', {
+          id: jobId,
+          status: 'completed',
+          progress: 100,
+          errorMessage: null,
+        });
+
+        setStatus('completed');
+        setCompletedOutputPath(result.output_path);
+
+        // Add complete message with output path
+        const filename = result.output_path.split('/').pop() || 'Output ready';
+        addMessage('complete', filename, { outputPath: result.output_path });
+
+        await loadHistory();
+      } catch (error) {
+        const errorMessage = localizeUnknownError(error);
+        setStatus('error');
+        addMessage('system', `Failed: ${errorMessage}`);
+      } finally {
+        setIsGenerating(false);
+        setIsProcessing(false);
+        setProgress(null);
+        setCurrentJobId(null);
+      }
+    },
+    [
+      videoPath,
+      videoMetadata,
+      selection,
+      isGenerating,
+      attachedImages,
+      addMessage,
+      loadHistory,
+      outputDirectory,
+    ],
+  );
+
+  // Generate command from quick action
+  const generateCommand = useCallback(
+    async (taskType: ProcessingTaskType, options?: Record<string, unknown>) => {
+      if (!videoMetadata) return;
+
+      setIsGenerating(true);
+      setStatus('generating');
+
+      try {
+        const result = await invoke<FFmpegCommandResult>('generate_quick_action_command', {
+          inputPath: videoPath,
+          taskType,
+          options: options ?? {},
+          timelineStart: selection?.start ?? null,
+          timelineEnd: selection?.end ?? null,
+          metadata: videoMetadata,
+          outputDir: outputDirectory || null,
+        });
+
+        setGeneratedCommand(result);
+        setStatus('ready');
+
+        // Add to chat
+        const assistantMessage: ChatMessage = {
+          id: crypto.randomUUID(),
+          role: 'assistant',
+          content: `**${taskType.replace('_', ' ').toUpperCase()}**\n\n${result.explanation}`,
+          timestamp: new Date().toISOString(),
+          command: result,
+        };
+        setMessages((prev) => [...prev, assistantMessage]);
+      } catch (error) {
+        const errorMessage = localizeUnknownError(error);
+        setStatus('error');
+        console.error('Failed to generate command:', errorMessage);
+      } finally {
+        setIsGenerating(false);
+      }
+    },
+    [videoPath, videoMetadata, selection, outputDirectory],
+  );
+
+  // Execute FFmpeg command
+  const executeCommand = useCallback(
+    async (command?: FFmpegCommandResult) => {
+      const cmdToExecute = command ?? generatedCommand;
+      if (!cmdToExecute || !videoPath) return;
+
+      setStatus('processing');
+      setIsProcessing(true);
+      setProgress(null);
+      setCompletedOutputPath(null);
+
+      const jobId = crypto.randomUUID();
+      setCurrentJobId(jobId);
+
+      try {
+        // Save job to history
+        await invoke('save_processing_job', {
+          id: jobId,
+          inputPath: videoPath,
+          outputPath: cmdToExecute.output_path,
+          taskType: 'custom',
+          userPrompt: messages.find((m) => m.role === 'user')?.content ?? null,
+          ffmpegCommand: cmdToExecute.command,
+        });
+
+        await invoke('execute_ffmpeg_command', {
+          jobId,
+          commandArgs: cmdToExecute.command_args,
+          inputPath: videoPath,
+          outputPath: cmdToExecute.output_path,
+        });
+
+        // Update job status
+        await invoke('update_processing_job', {
+          id: jobId,
+          status: 'completed',
+          progress: 100,
+          errorMessage: null,
+        });
+
+        setStatus('completed');
+        setCompletedOutputPath(cmdToExecute.output_path);
+        setGeneratedCommand(null);
+
+        // Add complete message with output path
+        const filename = cmdToExecute.output_path.split('/').pop() || 'Output ready';
+        addMessage('complete', filename, { outputPath: cmdToExecute.output_path });
+
+        await loadHistory();
+      } catch (error) {
+        const errorMessage = localizeUnknownError(error);
+        setStatus('error');
+        addMessage('system', `Failed: ${errorMessage}`);
+
+        // Update job with error
+        await invoke('update_processing_job', {
+          id: jobId,
+          status: 'failed',
+          progress: 0,
+          errorMessage: errorMessage,
+        });
+
+        console.error('FFmpeg execution failed:', errorMessage);
+      } finally {
+        setIsProcessing(false);
+        setProgress(null);
+        setCurrentJobId(null);
+        await loadHistory();
+      }
+    },
+    [generatedCommand, videoPath, messages, addMessage, loadHistory],
+  );
+
+  // Cancel processing
+  const cancelProcessing = useCallback(async () => {
+    if (currentJobId) {
+      try {
+        await invoke('cancel_ffmpeg', { jobId: currentJobId });
+        await invoke('update_processing_job', {
+          id: currentJobId,
+          status: 'cancelled',
+          progress: 0,
+          errorMessage: 'Cancelled',
+        });
+        addMessage('system', 'Cancelled');
+      } catch (error) {
+        console.error('Failed to cancel:', error);
+      }
+    }
+    setStatus('idle');
+    setIsProcessing(false);
+    setProgress(null);
+    setCurrentJobId(null);
+    await loadHistory();
+  }, [currentJobId, addMessage, loadHistory]);
+
+  // Clear generated command
+  const clearCommand = useCallback(() => {
+    setGeneratedCommand(null);
+    setStatus('idle');
+  }, []);
+
+  // Open output folder in file manager
+  const openOutputFolder = useCallback(async () => {
+    if (completedOutputPath) {
+      try {
+        await invoke('open_file_location', { filepath: completedOutputPath });
+      } catch (error) {
+        console.error('Failed to open folder:', error);
+      }
+    }
+  }, [completedOutputPath]);
+
+  // Delete job from history
+  const deleteJob = useCallback(async (id: string) => {
+    try {
+      await invoke('delete_processing_job', { id });
+      setHistory((prev) => prev.filter((job) => job.id !== id));
+    } catch (error) {
+      console.error('Failed to delete job:', error);
+    }
+  }, []);
+
+  // Clear all history
+  const clearHistory = useCallback(async () => {
+    try {
+      await invoke('clear_processing_history');
+      setHistory([]);
+    } catch (error) {
+      console.error('Failed to clear history:', error);
+    }
+  }, []);
+
+  // Load presets
+  const loadPresets = useCallback(async () => {
+    try {
+      const savedPresets = await invoke<ProcessingPreset[]>('get_processing_presets');
+      setPresets(savedPresets);
+    } catch (error) {
+      console.error('Failed to load presets:', error);
+    }
+  }, []);
+
+  // Save preset
+  const savePreset = useCallback(
+    async (name: string, description?: string) => {
+      if (!generatedCommand) return;
+
+      try {
+        await invoke('save_processing_preset', {
+          name,
+          description,
+          command: generatedCommand.command,
+          taskType: 'custom',
+        });
+        await loadPresets();
+      } catch (error) {
+        console.error('Failed to save preset:', error);
+      }
+    },
+    [generatedCommand, loadPresets],
+  );
+
+  // Delete preset
+  const deletePreset = useCallback(async (id: string) => {
+    try {
+      await invoke('delete_processing_preset', { id });
+      setPresets((prev) => prev.filter((p) => p.id !== id));
+    } catch (error) {
+      console.error('Failed to delete preset:', error);
+    }
+  }, []);
+
+  // Apply preset
+  const applyPreset = useCallback(
+    async (preset: ProcessingPreset) => {
+      await sendMessage(preset.prompt_template);
+    },
+    [sendMessage],
+  );
+
+  // Batch operations
+  const addBatchFile = useCallback((path: string) => {
+    setBatchFiles((prev) => [...prev, path]);
+  }, []);
+
+  const removeBatchFile = useCallback((path: string) => {
+    setBatchFiles((prev) => prev.filter((p) => p !== path));
+  }, []);
+
+  const clearBatch = useCallback(() => {
+    setBatchFiles([]);
+  }, []);
+
+  const processBatch = useCallback(async () => {
+    if (!generatedCommand || batchFiles.length === 0) return;
+
+    // Process each file with the same command template
+    for (const file of batchFiles) {
+      try {
+        await invoke('execute_ffmpeg_batch', {
+          commandArgs: generatedCommand.command_args,
+          inputPath: file,
+        });
+      } catch (error) {
+        console.error(`Batch processing failed for ${file}:`, error);
+      }
+    }
+
+    await loadHistory();
+  }, [generatedCommand, batchFiles, loadHistory]);
+
+  // Reset all state
+  const reset = useCallback(() => {
+    setVideoPath(null);
+    setVideoSrc(null);
+    setAudioSrc(null);
+    setThumbnailSrc(null);
+    setVideoMetadata(null);
+    setVideoError(null);
+    setDuration(0);
+    setCurrentTime(0);
+    setSelection(null);
+    setStatus('idle');
+    setIsProcessing(false);
+    setCurrentJob(null);
+    setCurrentJobId(null);
+    setProgress(null);
+    setGeneratedCommand(null);
+    setCompletedOutputPath(null);
+    setMessages([]);
+    setOutputDirectory('');
+    setBatchFiles([]);
+  }, []);
+
+  return (
+    <ProcessingContext.Provider
+      value={{
+        videoPath,
+        videoSrc,
+        audioSrc,
+        thumbnailSrc,
+        videoMetadata,
+        isLoadingVideo,
+        isGeneratingPreview,
+        isUsingPreview,
+        videoError,
+        duration,
+        pendingPreviewConfirm,
+        confirmPreview,
+        previewSizeThreshold,
+        setPreviewSizeThreshold,
+        currentTime,
+        selection,
+        status,
+        isProcessing,
+        currentJob,
+        currentJobId,
+        progress,
+        generatedCommand,
+        completedOutputPath,
+        messages,
+        isGenerating,
+        outputDirectory,
+        attachedImages,
+        history,
+        presets,
+        batchFiles,
+        selectVideo,
+        loadVideo,
+        setVideoError,
+        setCurrentTime,
+        setDuration,
+        setSelection,
+        addMessage,
+        sendMessage,
+        selectOutputDirectory,
+        generateCommand,
+        attachImages,
+        removeAttachment,
+        clearAttachments,
+        executeCommand,
+        cancelProcessing,
+        clearCommand,
+        openOutputFolder,
+        loadHistory,
+        deleteJob,
+        clearHistory,
+        loadPresets,
+        savePreset,
+        deletePreset,
+        applyPreset,
+        addBatchFile,
+        removeBatchFile,
+        clearBatch,
+        processBatch,
+        reset,
+      }}
+    >
+      {children}
+    </ProcessingContext.Provider>
+  );
 }
 
 export function useProcessing() {
   const context = useContext(ProcessingContext);
   if (!context) {
-    throw new Error('useProcessing must be used within a ProcessingProvider');
+    throw new Error('useProcessing must be used within ProcessingProvider');
   }
   return context;
 }
-
-export type { PreviewConfirmInfo, ProcessingContextValue };


### PR DESCRIPTION
## Problem

The **Show in Folder** / **Open Folder** button on completed download items does nothing on macOS. Clicking it silently fails with no feedback.

## Root Cause

All queue item components (`QueueItem`, `UniversalQueueItem`, `GalleryQueueItem`, `ChatPanel`, `HistoryDialog`, `ProcessingContext`) were using `revealItemInDir()` from `@tauri-apps/plugin-opener`. On macOS this fails silently because:

1. `dunce::canonicalize()` throws if the file doesn't exist on disk
2. `NSWorkspace::activateFileViewerSelectingURLs` errors are not surfaced to the JS layer
3. The `catch` block only does `console.error` — no user feedback

## Fix

Replace all `revealItemInDir()` calls with `invoke('open_file_location')` — the existing Rust command in `history.rs` that uses platform-native commands:
- **macOS**: `open -R <path>` (reveals in Finder)
- **Windows**: `explorer /select,<path>`
- **Linux**: `xdg-open <parent dir>`

Also improved `open_file_location` to fall back to the parent directory if the exact file no longer exists (e.g. renamed after download), instead of returning an error.

## Files Changed

- `src/components/download/QueueItem.tsx`
- `src/components/download/UniversalQueueItem.tsx`
- `src/components/download/GalleryQueueItem.tsx`
- `src/components/processing/ChatPanel.tsx`
- `src/components/processing/HistoryDialog.tsx`
- `src/contexts/ProcessingContext.tsx`
- `src-tauri/src/commands/history.rs`