### PR TITLE
fix(ui): route file reveal actions through app command

### DIFF
--- a/src/components/download/GalleryQueueItem.tsx
+++ b/src/components/download/GalleryQueueItem.tsx
@@ -1,7 +1,7 @@
-import { revealItemInDir } from '@tauri-apps/plugin-opener';
 import { CheckCircle2, Clock, FolderOpen, Globe, Loader2, X, XCircle } from 'lucide-react';
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
+import { openFileLocation } from '@/lib/open-file-location';
 import type { DownloadItem } from '@/lib/types';
 import { cn } from '@/lib/utils';
 
@@ -27,7 +27,7 @@ export function GalleryQueueItem({
   const handleOpenFolder = useCallback(async () => {
     if (!item.completedFilepath) return;
     try {
-      await revealItemInDir(item.completedFilepath);
+      await openFileLocation(item.completedFilepath);
     } catch (error) {
       console.error('Failed to open gallery output folder:', error);
     }

--- a/src/components/download/QueueItem.tsx
+++ b/src/components/download/QueueItem.tsx
@@ -1,4 +1,3 @@
-import { revealItemInDir } from '@tauri-apps/plugin-opener';
 import {
   CheckCircle2,
   ChevronDown,
@@ -24,6 +23,7 @@ import { SchedulePopover } from '@/components/download/SchedulePopover';
 import { SimpleMarkdown } from '@/components/ui/simple-markdown';
 import { useAI } from '@/contexts/AIContext';
 import type { ScheduleConfig } from '@/hooks/useSchedule';
+import { openFileLocation } from '@/lib/open-file-location';
 import type { DownloadItem, ItemDownloadSettings } from '@/lib/types';
 import { cn } from '@/lib/utils';
 import { extractYouTubeVideoId, youtubeThumbnailUrl } from '@/lib/youtube-url';
@@ -233,7 +233,7 @@ export function QueueItem({
     if (!item.completedFilepath) return;
 
     try {
-      await revealItemInDir(item.completedFilepath);
+      await openFileLocation(item.completedFilepath);
     } catch (error) {
       console.error('Failed to open completed file location:', error);
     }

--- a/src/components/download/UniversalQueueItem.tsx
+++ b/src/components/download/UniversalQueueItem.tsx
@@ -1,4 +1,3 @@
-import { revealItemInDir } from '@tauri-apps/plugin-opener';
 import {
   CheckCircle2,
   ChevronDown,
@@ -24,6 +23,7 @@ import { SchedulePopover } from '@/components/download/SchedulePopover';
 import { SimpleMarkdown } from '@/components/ui/simple-markdown';
 import { useAI } from '@/contexts/AIContext';
 import type { ScheduleConfig } from '@/hooks/useSchedule';
+import { openFileLocation } from '@/lib/open-file-location';
 import type { DownloadItem, ItemUniversalSettings } from '@/lib/types';
 import { cn } from '@/lib/utils';
 import { SourceBadge } from './SourceBadge';
@@ -215,7 +215,7 @@ export function UniversalQueueItem({
     if (!item.completedFilepath) return;
 
     try {
-      await revealItemInDir(item.completedFilepath);
+      await openFileLocation(item.completedFilepath);
     } catch (error) {
       console.error('Failed to open completed file location:', error);
     }

--- a/src/components/processing/ChatPanel.tsx
+++ b/src/components/processing/ChatPanel.tsx
@@ -1,5 +1,4 @@
 import { open } from '@tauri-apps/plugin-dialog';
-import { revealItemInDir } from '@tauri-apps/plugin-opener';
 import {
   Check,
   FileText,
@@ -20,6 +19,7 @@ import { type DragEvent, useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { openFileLocation } from '@/lib/open-file-location';
 import type { ChatAttachment, ChatMessage, ProcessingProgress } from '@/lib/types';
 import { cn } from '@/lib/utils';
 
@@ -403,7 +403,7 @@ export function ChatPanel({
                     <button
                       type="button"
                       className="flex items-center gap-1 text-xs font-medium text-green-600 dark:text-green-400 hover:underline w-fit"
-                      onClick={() => msg.outputPath && revealItemInDir(msg.outputPath)}
+                      onClick={() => msg.outputPath && void openFileLocation(msg.outputPath)}
                     >
                       <FolderOpen className="w-3 h-3" />
                       {t('processing.chat.openInFolder')}

--- a/src/components/processing/HistoryDialog.tsx
+++ b/src/components/processing/HistoryDialog.tsx
@@ -1,4 +1,3 @@
-import { revealItemInDir } from '@tauri-apps/plugin-opener';
 import {
   AlertCircle,
   Calendar,
@@ -27,6 +26,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/u
 import { Input } from '@/components/ui/input';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { ScrollArea } from '@/components/ui/scroll-area';
+import { openFileLocation } from '@/lib/open-file-location';
 import type { ProcessingJob } from '@/lib/types';
 import { cn } from '@/lib/utils';
 
@@ -620,7 +620,8 @@ export function HistoryDialog({
                         <Button
                           size="sm"
                           onClick={() =>
-                            selectedJob.output_path && revealItemInDir(selectedJob.output_path)
+                            selectedJob.output_path &&
+                            void openFileLocation(selectedJob.output_path)
                           }
                           className="gap-1.5"
                         >

--- a/src/contexts/processing/processing-client.ts
+++ b/src/contexts/processing/processing-client.ts
@@ -2,7 +2,7 @@ import { invoke } from '@tauri-apps/api/core';
 import { listen, type UnlistenFn } from '@tauri-apps/api/event';
 import { open } from '@tauri-apps/plugin-dialog';
 import { readFile } from '@tauri-apps/plugin-fs';
-import { revealItemInDir } from '@tauri-apps/plugin-opener';
+import { openFileLocation } from '@/lib/open-file-location';
 import type {
   FFmpegCommandResult,
   ProcessingJob,
@@ -150,7 +150,7 @@ export async function cancelFfmpeg(jobId: string): Promise<void> {
 }
 
 export async function revealOutputInFolder(path: string): Promise<void> {
-  await revealItemInDir(path);
+  await openFileLocation(path);
 }
 
 export async function deleteProcessingJob(id: string): Promise<void> {

--- a/src/lib/open-file-location.ts
+++ b/src/lib/open-file-location.ts
@@ -1,0 +1,5 @@
+import { invoke } from '@tauri-apps/api/core';
+
+export async function openFileLocation(filepath: string): Promise<void> {
+  await invoke('open_file_location', { filepath });
+}


### PR DESCRIPTION
## Summary
- Add a small frontend `openFileLocation()` helper that calls the existing `open_file_location` Tauri command.
- Route queue and processing "Show/Open in folder" actions through that helper instead of calling `revealItemInDir` directly.
- Keep the change intentionally smaller than the broader ProcessingContext diff in #94.

## Why
The app already has platform-aware Rust handling for `open_file_location`. Reusing that command keeps reveal behavior centralized while avoiding extra frontend context churn.

## Tested
- `biome check` targeted to changed files
- `bun run tsc -b`
- `cargo check` in `src-tauri` after restoring the bundled yt-dlp binary in the clean Windows worktree
- Manual Windows custom-build check: downloaded `sample-5s.mp4`, clicked Show in folder, Explorer opened the containing Downloads folder

## Notes
Full repo Biome on this Windows PR worktree is noisy because unrelated untouched files are checked out with CRLF line endings. The changed files pass targeted Biome after normalization.

Related: #94