### PR TITLE
feat(ui): extract URLs from pasted text in shared parser

### DIFF
--- a/src/components/download/GalleryUrlInput.tsx
+++ b/src/components/download/GalleryUrlInput.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
-import { isValidUrl, normalizeShellEscapedUrl } from '@/lib/sources';
+import { extractUrls } from '@/lib/sources';
 import { cn } from '@/lib/utils';
 
 interface GalleryUrlInputProps {
@@ -15,13 +15,7 @@ interface GalleryUrlInputProps {
 }
 
 function countUrls(text: string): number {
-  return text
-    .trim()
-    .split('\n')
-    .filter((line) => {
-      const trimmed = normalizeShellEscapedUrl(line);
-      return trimmed && !trimmed.startsWith('#') && isValidUrl(trimmed);
-    }).length;
+  return extractUrls(text).length;
 }
 
 export function GalleryUrlInput({

--- a/src/components/download/UniversalUrlInput.tsx
+++ b/src/components/download/UniversalUrlInput.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
-import { isValidUrl, normalizeShellEscapedUrl } from '@/lib/sources';
+import { extractUrls } from '@/lib/sources';
 import { cn } from '@/lib/utils';
 
 interface UniversalUrlInputProps {
@@ -15,13 +15,7 @@ interface UniversalUrlInputProps {
 }
 
 function countUrls(text: string): number {
-  return text
-    .trim()
-    .split('\n')
-    .filter((l) => {
-      const trimmed = normalizeShellEscapedUrl(l);
-      return trimmed && !trimmed.startsWith('#') && isValidUrl(trimmed);
-    }).length;
+  return extractUrls(text).length;
 }
 
 export function UniversalUrlInput({

--- a/src/components/download/UrlInput.tsx
+++ b/src/components/download/UrlInput.tsx
@@ -23,7 +23,7 @@ import {
 } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
-import { normalizeShellEscapedUrl } from '@/lib/sources';
+import { extractUrls } from '@/lib/sources';
 import { cn } from '@/lib/utils';
 import { VideoPreview } from './VideoPreview';
 
@@ -40,16 +40,9 @@ interface UrlInputProps {
 }
 
 function extractFirstUrl(text: string): string | null {
-  const lines = text.split('\n');
-  for (const line of lines) {
-    const trimmed = normalizeShellEscapedUrl(line);
-    if (trimmed && !trimmed.startsWith('#')) {
-      if (trimmed.includes('youtube.com') || trimmed.includes('youtu.be')) {
-        return trimmed;
-      }
-    }
-  }
-  return null;
+  return (
+    extractUrls(text).find((url) => url.includes('youtube.com') || url.includes('youtu.be')) ?? null
+  );
 }
 
 function isPlaylistOnlyUrl(url: string): boolean {
@@ -60,17 +53,8 @@ function isPlaylistOnlyUrl(url: string): boolean {
 }
 
 function countUrls(text: string): number {
-  return text
-    .trim()
-    .split('\n')
-    .filter((l) => {
-      const trimmed = normalizeShellEscapedUrl(l);
-      return (
-        trimmed &&
-        !trimmed.startsWith('#') &&
-        (trimmed.includes('youtube.com') || trimmed.includes('youtu.be'))
-      );
-    }).length;
+  return extractUrls(text).filter((url) => url.includes('youtube.com') || url.includes('youtu.be'))
+    .length;
 }
 
 export function UrlInput({

--- a/src/contexts/DownloadContext.tsx
+++ b/src/contexts/DownloadContext.tsx
@@ -53,7 +53,7 @@ import {
   refreshPluginWorkflowSnapshots,
   refreshPostDownloadWorkflowSteps,
 } from '@/lib/post-download-plugins';
-import { normalizeShellEscapedUrl } from '@/lib/sources';
+import { extractUrls } from '@/lib/sources';
 import type {
   AudioBitrate,
   CookieSettings,
@@ -509,15 +509,9 @@ export function DownloadProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const parseUrls = useCallback((text: string): string[] => {
-    return text
-      .split('\n')
-      .map(normalizeShellEscapedUrl)
-      .filter((line) => {
-        // Skip empty lines and comments
-        if (!line || line.startsWith('#')) return false;
-        // Check for valid YouTube URLs
-        return line.includes('youtube.com') || line.includes('youtu.be');
-      });
+    return extractUrls(text).filter(
+      (url) => url.includes('youtube.com') || url.includes('youtu.be'),
+    );
   }, []);
 
   // Helper to check if URL is a playlist

--- a/src/contexts/MetadataContext.tsx
+++ b/src/contexts/MetadataContext.tsx
@@ -4,6 +4,7 @@ import { downloadDir, homeDir } from '@tauri-apps/api/path';
 import { open } from '@tauri-apps/plugin-dialog';
 import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { localizeProgressError, localizeUnknownError } from '@/lib/backend-error';
+import { extractUrls } from '@/lib/sources';
 import { useDownload } from './download-context';
 import { MetadataContext } from './metadata-context';
 
@@ -160,18 +161,7 @@ export function MetadataProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const parseUrls = useCallback((text: string): string[] => {
-    return text
-      .split('\n')
-      .map((line) => line.trim())
-      .filter((line) => {
-        if (!line || line.startsWith('#')) return false;
-        return (
-          line.includes('youtube.com') ||
-          line.includes('youtu.be') ||
-          line.includes('http://') ||
-          line.includes('https://')
-        );
-      });
+    return extractUrls(text);
   }, []);
 
   const addUrls = useCallback(

--- a/src/lib/sources.ts
+++ b/src/lib/sources.ts
@@ -216,17 +216,52 @@ function isShellEscapedUrlChar(char: string): boolean {
   return "?=&#%+:/._-~@!$'()*,;[]".includes(char);
 }
 
+const URL_PATTERN = /https?:\/\/[^\s<>"'`]+/gi;
+const TRAILING_URL_PUNCTUATION = '.,;:!?)]}';
+
+function cleanExtractedUrl(candidate: string): string {
+  let url = normalizeShellEscapedUrl(candidate);
+  while (url && TRAILING_URL_PUNCTUATION.includes(url.charAt(url.length - 1))) {
+    url = url.slice(0, -1);
+  }
+  return url;
+}
+
+/**
+ * Extract HTTP/HTTPS URLs from pasted text while preserving order.
+ */
+export function extractUrls(text: string): string[] {
+  const urls: string[] = [];
+  const seen = new Set<string>();
+
+  const addUrl = (candidate: string) => {
+    const url = cleanExtractedUrl(candidate);
+    if (!url || !isValidUrl(url) || seen.has(url)) return;
+    seen.add(url);
+    urls.push(url);
+  };
+
+  for (const line of text.split('\n')) {
+    const normalizedLine = normalizeShellEscapedUrl(line);
+    if (!normalizedLine || normalizedLine.startsWith('#')) continue;
+
+    const matches = normalizedLine.match(URL_PATTERN);
+    if (matches) {
+      for (const match of matches) {
+        addUrl(match);
+      }
+      continue;
+    }
+
+    addUrl(normalizedLine);
+  }
+
+  return urls;
+}
+
 /**
  * Parse URLs from text input, filtering for valid HTTP/HTTPS URLs
  */
 export function parseUniversalUrls(text: string): string[] {
-  return text
-    .split('\n')
-    .map(normalizeShellEscapedUrl)
-    .filter((line) => {
-      // Skip empty lines and comments
-      if (!line || line.startsWith('#')) return false;
-      // Validate URL format
-      return isValidUrl(line);
-    });
+  return extractUrls(text);
 }

--- a/tests/source-url-extraction.test.ts
+++ b/tests/source-url-extraction.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from 'bun:test';
+import { extractUrls, parseUniversalUrls } from '../src/lib/sources';
+
+describe('extractUrls', () => {
+  test('extracts URLs embedded in pasted text', () => {
+    expect(extractUrls('Watch this video: https://www.youtube.com/watch?v=abc123.')).toEqual([
+      'https://www.youtube.com/watch?v=abc123',
+    ]);
+  });
+
+  test('preserves order, deduplicates, and skips comment lines', () => {
+    expect(
+      extractUrls(
+        [
+          '# https://ignored.example/video',
+          'first https://www.instagram.com/reel/abc/',
+          'repeat https://www.instagram.com/reel/abc/',
+          'second https://www.tiktok.com/@demo/video/123)',
+        ].join('\n'),
+      ),
+    ).toEqual(['https://www.instagram.com/reel/abc/', 'https://www.tiktok.com/@demo/video/123']);
+  });
+
+  test('normalizes shell-escaped URLs', () => {
+    expect(extractUrls('https://www.youtube.com/watch\\?v=abc123\\&t=30s')).toEqual([
+      'https://www.youtube.com/watch?v=abc123&t=30s',
+    ]);
+  });
+
+  test('keeps universal parser aligned with extraction behavior', () => {
+    expect(parseUniversalUrls('link: https://www.facebook.com/reel/123,')).toEqual([
+      'https://www.facebook.com/reel/123',
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a shared `extractUrls()` helper in `src/lib/sources.ts` for extracting HTTP(S) URLs from pasted text.
- Reuses that helper across YouTube Download inputs, Universal/Gallery URL counters, `parseUniversalUrls()`, DownloadContext, and MetadataContext.
- Leaves context architecture unchanged and keeps the existing `cookieSkipPatterns` filtering in MetadataContext.

## Context
This is a focused follow-up to #95 after maintainer feedback requested a shared parser in `src/lib/sources.ts` instead of a MetadataContext-only change.

## Tests
- `bunx biome check --write src/lib/sources.ts src/components/download/UrlInput.tsx src/components/download/UniversalUrlInput.tsx src/components/download/GalleryUrlInput.tsx src/contexts/DownloadContext.tsx src/contexts/MetadataContext.tsx tests/source-url-extraction.test.ts`
- `bun test tests/source-url-extraction.test.ts`
- `bun run tsc -b`

## Local Windows check notes
- Full `bun run lint` in this clean upstream worktree is blocked by existing CRLF formatter diagnostics across unrelated files.
- `cargo check` in this clean upstream worktree is blocked by the missing bundled yt-dlp resource `bin\youwee-yt-dlp-x86_64-pc-windows-msvc.exe`.