### PR TITLE
feat(ui): copy URLs from download queue items

### DIFF
--- a/src/components/download/QueueItem.tsx
+++ b/src/components/download/QueueItem.tsx
@@ -1,9 +1,11 @@
 import {
+  Check,
   CheckCircle2,
   ChevronDown,
   ChevronUp,
   CircleSlash,
   Clock,
+  Copy,
   FolderOpen,
   HardDrive,
   Lightbulb,
@@ -135,6 +137,7 @@ export function QueueItem({
   const [renameName, setRenameName] = useState('');
   const [renameError, setRenameError] = useState<string | null>(null);
   const [isRenaming, setIsRenaming] = useState(false);
+  const [copiedUrl, setCopiedUrl] = useState(false);
   // Use background task for summary - taskId is based on item.id
   const taskId = `queue-${item.id}`;
   const task = ai.getSummaryTask(taskId);
@@ -238,6 +241,16 @@ export function QueueItem({
       console.error('Failed to open completed file location:', error);
     }
   }, [item.completedFilepath]);
+
+  const handleCopyUrl = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(item.url);
+      setCopiedUrl(true);
+      window.setTimeout(() => setCopiedUrl(false), 2000);
+    } catch (error) {
+      console.error('Failed to copy queue URL:', error);
+    }
+  }, [item.url]);
 
   const handleCancelRename = useCallback(() => {
     setShowRenameEditor(false);
@@ -597,6 +610,16 @@ export function QueueItem({
                 {t('queue.openFolder')}
               </button>
             )}
+
+            <button
+              type="button"
+              onClick={handleCopyUrl}
+              aria-label={t('queue.copyUrl')}
+              className="inline-flex items-center gap-1 text-[11px] px-2 py-0.5 rounded-md border border-dashed border-muted-foreground/30 text-muted-foreground hover:border-muted-foreground/50 hover:text-foreground hover:bg-muted/50 transition-colors font-medium"
+            >
+              {copiedUrl ? <Check className="w-3 h-3" /> : <Copy className="w-3 h-3" />}
+              {copiedUrl ? t('queue.copied') : t('queue.copyUrl')}
+            </button>
 
             {isCompleted && item.completedFilepath && (
               <button

--- a/src/components/download/UniversalQueueItem.tsx
+++ b/src/components/download/UniversalQueueItem.tsx
@@ -1,9 +1,11 @@
 import {
+  Check,
   CheckCircle2,
   ChevronDown,
   ChevronUp,
   CircleSlash,
   Clock,
+  Copy,
   FolderOpen,
   Globe,
   HardDrive,
@@ -134,6 +136,7 @@ export function UniversalQueueItem({
   const [renameName, setRenameName] = useState('');
   const [renameError, setRenameError] = useState<string | null>(null);
   const [isRenaming, setIsRenaming] = useState(false);
+  const [copiedUrl, setCopiedUrl] = useState(false);
   const handleThumbError = useCallback(() => {
     setThumbError(true);
   }, []);
@@ -220,6 +223,16 @@ export function UniversalQueueItem({
       console.error('Failed to open completed file location:', error);
     }
   }, [item.completedFilepath]);
+
+  const handleCopyUrl = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(item.url);
+      setCopiedUrl(true);
+      window.setTimeout(() => setCopiedUrl(false), 2000);
+    } catch (error) {
+      console.error('Failed to copy queue URL:', error);
+    }
+  }, [item.url]);
 
   const handleCancelRename = useCallback(() => {
     setShowRenameEditor(false);
@@ -595,6 +608,16 @@ export function UniversalQueueItem({
                 {t('queue.openFolder')}
               </button>
             )}
+
+            <button
+              type="button"
+              onClick={handleCopyUrl}
+              aria-label={t('queue.copyUrl')}
+              className="inline-flex items-center gap-1 text-[11px] px-2 py-0.5 rounded-md border border-dashed border-muted-foreground/30 text-muted-foreground hover:border-muted-foreground/50 hover:text-foreground hover:bg-muted/50 transition-colors font-medium"
+            >
+              {copiedUrl ? <Check className="w-3 h-3" /> : <Copy className="w-3 h-3" />}
+              {copiedUrl ? t('queue.copied') : t('queue.copyUrl')}
+            </button>
 
             {isCompleted && item.completedFilepath && (
               <button

--- a/src/i18n/locales/ar/download.json
+++ b/src/i18n/locales/ar/download.json
@@ -207,6 +207,8 @@
     },
     "summarize": "تلخيص",
     "openFolder": "إظهار في المجلد",
+    "copyUrl": "نسخ الرابط",
+    "copied": "تم النسخ",
     "changeOutputFolder": "تغيير المجلد",
     "outputFolder": "مجلد التنزيل: {{path}}",
     "rename": "إعادة تسمية",

--- a/src/i18n/locales/ar/universal.json
+++ b/src/i18n/locales/ar/universal.json
@@ -117,6 +117,8 @@
     },
     "summarize": "تلخيص",
     "openFolder": "إظهار في المجلد",
+    "copyUrl": "نسخ الرابط",
+    "copied": "تم النسخ",
     "changeOutputFolder": "تغيير المجلد",
     "outputFolder": "مجلد التنزيل: {{path}}",
     "rename": "إعادة تسمية",

--- a/src/i18n/locales/en/download.json
+++ b/src/i18n/locales/en/download.json
@@ -207,6 +207,8 @@
     },
     "summarize": "Summarize",
     "openFolder": "Show in folder",
+    "copyUrl": "Copy URL",
+    "copied": "Copied",
     "changeOutputFolder": "Change folder",
     "outputFolder": "Download folder: {{path}}",
     "rename": "Rename",

--- a/src/i18n/locales/en/universal.json
+++ b/src/i18n/locales/en/universal.json
@@ -117,6 +117,8 @@
     },
     "summarize": "Summarize",
     "openFolder": "Show in folder",
+    "copyUrl": "Copy URL",
+    "copied": "Copied",
     "changeOutputFolder": "Change folder",
     "outputFolder": "Download folder: {{path}}",
     "rename": "Rename",

--- a/src/i18n/locales/es/download.json
+++ b/src/i18n/locales/es/download.json
@@ -207,6 +207,8 @@
     },
     "summarize": "Resumir",
     "openFolder": "Mostrar en carpeta",
+    "copyUrl": "Copiar URL",
+    "copied": "Copiado",
     "changeOutputFolder": "Cambiar carpeta",
     "outputFolder": "Carpeta de descarga: {{path}}",
     "rename": "Renombrar",

--- a/src/i18n/locales/es/universal.json
+++ b/src/i18n/locales/es/universal.json
@@ -117,6 +117,8 @@
     },
     "summarize": "Resumir",
     "openFolder": "Mostrar en carpeta",
+    "copyUrl": "Copiar URL",
+    "copied": "Copiado",
     "changeOutputFolder": "Cambiar carpeta",
     "outputFolder": "Carpeta de descarga: {{path}}",
     "rename": "Renombrar",

--- a/src/i18n/locales/fr/download.json
+++ b/src/i18n/locales/fr/download.json
@@ -213,6 +213,8 @@
     "playlist": "Playlist",
     "live": "LIVE",
     "openFolder": "Afficher dans le dossier",
+    "copyUrl": "Copier l’URL",
+    "copied": "Copié",
     "changeOutputFolder": "Changer de dossier",
     "outputFolder": "Dossier de téléchargement : {{path}}",
     "rename": "Renommer",

--- a/src/i18n/locales/fr/universal.json
+++ b/src/i18n/locales/fr/universal.json
@@ -122,6 +122,8 @@
     "showLess": "Afficher moins",
     "regenerateSummary": "Régénérer le résumé",
     "openFolder": "Afficher dans le dossier",
+    "copyUrl": "Copier l’URL",
+    "copied": "Copié",
     "changeOutputFolder": "Changer de dossier",
     "outputFolder": "Dossier de téléchargement : {{path}}",
     "rename": "Renommer",

--- a/src/i18n/locales/ja/download.json
+++ b/src/i18n/locales/ja/download.json
@@ -207,6 +207,8 @@
     },
     "summarize": "AI 要約",
     "openFolder": "フォルダに表示",
+    "copyUrl": "URLをコピー",
+    "copied": "コピー済み",
     "changeOutputFolder": "フォルダを変更",
     "outputFolder": "保存先フォルダ: {{path}}",
     "rename": "名前を変更",

--- a/src/i18n/locales/ja/universal.json
+++ b/src/i18n/locales/ja/universal.json
@@ -117,6 +117,8 @@
     },
     "summarize": "AI 要約",
     "openFolder": "フォルダに表示",
+    "copyUrl": "URLをコピー",
+    "copied": "コピー済み",
     "changeOutputFolder": "フォルダを変更",
     "outputFolder": "保存先フォルダ: {{path}}",
     "rename": "名前を変更",

--- a/src/i18n/locales/pt/download.json
+++ b/src/i18n/locales/pt/download.json
@@ -213,6 +213,8 @@
     "playlist": "Lista de Reprodução",
     "live": "AO VIVO",
     "openFolder": "Mostrar na pasta",
+    "copyUrl": "Copiar URL",
+    "copied": "Copiado",
     "changeOutputFolder": "Alterar pasta",
     "outputFolder": "Pasta de download: {{path}}",
     "rename": "Renomear",

--- a/src/i18n/locales/pt/universal.json
+++ b/src/i18n/locales/pt/universal.json
@@ -122,6 +122,8 @@
     "showLess": "Mostrar menos",
     "regenerateSummary": "Gerar resumo novamente",
     "openFolder": "Mostrar na pasta",
+    "copyUrl": "Copiar URL",
+    "copied": "Copiado",
     "changeOutputFolder": "Alterar pasta",
     "outputFolder": "Pasta de download: {{path}}",
     "rename": "Renomear",

--- a/src/i18n/locales/ru/download.json
+++ b/src/i18n/locales/ru/download.json
@@ -213,6 +213,8 @@
     "playlist": "Плейлист",
     "live": "ПРЯМОЙ ЭФИР",
     "openFolder": "Показать в папке",
+    "copyUrl": "Копировать URL",
+    "copied": "Скопировано",
     "changeOutputFolder": "Изменить папку",
     "outputFolder": "Папка загрузки: {{path}}",
     "rename": "Переименовать",

--- a/src/i18n/locales/ru/universal.json
+++ b/src/i18n/locales/ru/universal.json
@@ -122,6 +122,8 @@
     "showLess": "Показать меньше",
     "regenerateSummary": "Пересоздать сводку",
     "openFolder": "Показать в папке",
+    "copyUrl": "Копировать URL",
+    "copied": "Скопировано",
     "changeOutputFolder": "Изменить папку",
     "outputFolder": "Папка загрузки: {{path}}",
     "rename": "Переименовать",

--- a/src/i18n/locales/th/download.json
+++ b/src/i18n/locales/th/download.json
@@ -207,6 +207,8 @@
     },
     "summarize": "สรุป",
     "openFolder": "แสดงในโฟลเดอร์",
+    "copyUrl": "คัดลอก URL",
+    "copied": "คัดลอกแล้ว",
     "changeOutputFolder": "เปลี่ยนโฟลเดอร์",
     "outputFolder": "โฟลเดอร์ดาวน์โหลด: {{path}}",
     "rename": "เปลี่ยนชื่อ",

--- a/src/i18n/locales/th/universal.json
+++ b/src/i18n/locales/th/universal.json
@@ -117,6 +117,8 @@
     },
     "summarize": "สรุป",
     "openFolder": "แสดงในโฟลเดอร์",
+    "copyUrl": "คัดลอก URL",
+    "copied": "คัดลอกแล้ว",
     "changeOutputFolder": "เปลี่ยนโฟลเดอร์",
     "outputFolder": "โฟลเดอร์ดาวน์โหลด: {{path}}",
     "rename": "เปลี่ยนชื่อ",

--- a/src/i18n/locales/vi/download.json
+++ b/src/i18n/locales/vi/download.json
@@ -207,6 +207,8 @@
     },
     "summarize": "Tóm tắt",
     "openFolder": "Mở vị trí file",
+    "copyUrl": "Sao chép URL",
+    "copied": "Đã sao chép",
     "changeOutputFolder": "Đổi folder",
     "outputFolder": "Folder tải xuống: {{path}}",
     "rename": "Đổi tên",

--- a/src/i18n/locales/vi/universal.json
+++ b/src/i18n/locales/vi/universal.json
@@ -117,6 +117,8 @@
     },
     "summarize": "Tóm tắt",
     "openFolder": "Mở vị trí file",
+    "copyUrl": "Sao chép URL",
+    "copied": "Đã sao chép",
     "changeOutputFolder": "Đổi folder",
     "outputFolder": "Folder tải xuống: {{path}}",
     "rename": "Đổi tên",

--- a/src/i18n/locales/zh-CN/download.json
+++ b/src/i18n/locales/zh-CN/download.json
@@ -207,6 +207,8 @@
     },
     "summarize": "摘要",
     "openFolder": "打开所在文件夹",
+    "copyUrl": "复制链接",
+    "copied": "已复制",
     "changeOutputFolder": "更改文件夹",
     "outputFolder": "下载文件夹：{{path}}",
     "rename": "重命名",

--- a/src/i18n/locales/zh-CN/universal.json
+++ b/src/i18n/locales/zh-CN/universal.json
@@ -117,6 +117,8 @@
     },
     "summarize": "摘要",
     "openFolder": "打开所在文件夹",
+    "copyUrl": "复制链接",
+    "copied": "已复制",
     "changeOutputFolder": "更改文件夹",
     "outputFolder": "下载文件夹：{{path}}",
     "rename": "重命名",


### PR DESCRIPTION
## Summary
- add a Copy URL action to YouTube queue items
- add the same action to Universal queue items
- localize the action and copied state across all supported locales

## Why
Queue items already retain their source URL, but users currently have to return to Library or select the input manually to reuse it. This keeps the action directly beside existing item actions without changing queue state or download behavior.

## Validation
- `bun x biome check` on both components and all touched locale files
- `bun run tsc -b`
- `cargo check`
- `git diff --check upstream/main...HEAD`

No new dependency or persistence change.