### PR TITLE
fix: restore broken star history chart in README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,17 +181,17 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
   <source
     media="(prefers-color-scheme: dark)"
     srcset="
-      https://api.star-history.com/svg?repos=vanloctech/youwee&type=Date&theme=dark
+      https://star-history.dera.page/svg?repos=vanloctech/youwee&type=Date&theme=dark
     "
   />
   <source
     media="(prefers-color-scheme: light)"
     srcset="
-      https://api.star-history.com/svg?repos=vanloctech/youwee&type=Date
+      https://star-history.dera.page/svg?repos=vanloctech/youwee&type=Date
     "
   />
   <img
     alt="Star History Chart"
-    src="https://api.star-history.com/svg?repos=vanloctech/youwee&type=Date"
+    src="https://star-history.dera.page/svg?repos=vanloctech/youwee&type=Date"
   />
 </picture>

--- a/docs/README.vi.md
+++ b/docs/README.vi.md
@@ -181,18 +181,18 @@ Dự án này được cấp phép theo MIT License - xem file [LICENSE](../LICE
   <source
     media="(prefers-color-scheme: dark)"
     srcset="
-      https://api.star-history.com/svg?repos=vanloctech/youwee&type=Date&theme=dark
+      https://star-history.dera.page/svg?repos=vanloctech/youwee&type=Date&theme=dark
     "
   />
   <source
     media="(prefers-color-scheme: light)"
     srcset="
-      https://api.star-history.com/svg?repos=vanloctech/youwee&type=Date
+      https://star-history.dera.page/svg?repos=vanloctech/youwee&type=Date
     "
   />
   <img
     alt="Star History Chart"
-    src="https://api.star-history.com/svg?repos=vanloctech/youwee&type=Date"
+    src="https://star-history.dera.page/svg?repos=vanloctech/youwee&type=Date"
   />
 </picture>
 `

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -181,17 +181,17 @@ bun run tauri build
   <source
     media="(prefers-color-scheme: dark)"
     srcset="
-      https://api.star-history.com/svg?repos=vanloctech/youwee&type=Date&theme=dark
+      https://star-history.dera.page/svg?repos=vanloctech/youwee&type=Date&theme=dark
     "
   />
   <source
     media="(prefers-color-scheme: light)"
     srcset="
-      https://api.star-history.com/svg?repos=vanloctech/youwee&type=Date
+      https://star-history.dera.page/svg?repos=vanloctech/youwee&type=Date
     "
   />
   <img
     alt="Star History Chart"
-    src="https://api.star-history.com/svg?repos=vanloctech/youwee&type=Date"
+    src="https://star-history.dera.page/svg?repos=vanloctech/youwee&type=Date"
   />
 </picture>


### PR DESCRIPTION
The star history chart on the project homepage is currently broken, so visitors can no longer see how the repository has grown. This change restores the chart by pointing it to a working chart service, keeping the same look and layout in all README versions (English, Vietnamese, and Chinese).